### PR TITLE
fixed id field population and added assert to test

### DIFF
--- a/src/llmProviders/shared/baseProvider.ts
+++ b/src/llmProviders/shared/baseProvider.ts
@@ -160,7 +160,7 @@ export class BaseLLMProvider {
               if (localTool) {
                 outputMessages.push(
                   new ToolResponse(
-                    toolCall,
+                    toolCall.id,
                     'tool',
                     functionName,
                     '',
@@ -180,7 +180,7 @@ export class BaseLLMProvider {
             const filteredTool = this.filterTool(functionName);
             outputMessages.push(
               new ToolResponse(
-                toolCalls,
+                toolCall.id,
                 'tool',
                 functionName,
                 functionResponse,

--- a/test/openAIProvider.test.ts
+++ b/test/openAIProvider.test.ts
@@ -45,6 +45,7 @@ describe('Testing OpenAI Function Calling', () => {
 
     expect(toolResponse.length).toBeGreaterThan(0); // check that we've got tool responses
     expect(toolResponse[0].payloadRequest).toEqual('{}'); // check payload request stringified
+    expect(typeof toolResponse[0].toolCallId).toBe('string'); // check that response has correct id
   });
 
   it('tool selection is correct with tools in constructor', async () => {


### PR DESCRIPTION
Problem description: On returning tool response tool_call_id was set with an object instead of id string.
- fixed correct return value.
- added assert on type of return value in test.