### PR TITLE
feat(PRO-181): add local execution support for task handlers via CLI and SDK

### DIFF
--- a/src/xpander_sdk/modules/backend/frameworks/agno.py
+++ b/src/xpander_sdk/modules/backend/frameworks/agno.py
@@ -35,7 +35,7 @@ async def build_agent_args(
     args["tools"] = await _resolve_agent_tools(agent=xpander_agent)
 
     # team
-    if xpander_agent.agno_settings.coordinate_mode:
+    if xpander_agent.agno_settings.coordinate_mode and xpander_agent.graph.sub_agents and len(xpander_agent.graph.sub_agents) != 0:
         sub_agents = xpander_agent.graph.sub_agents
         
         # load sub agents

--- a/src/xpander_sdk/modules/events/decorators/on_task.py
+++ b/src/xpander_sdk/modules/events/decorators/on_task.py
@@ -32,13 +32,17 @@ Example usage:
 """
 
 import asyncio
+import argparse
+import json
+import sys
 from functools import wraps
 from inspect import iscoroutinefunction, signature
 from typing import Optional, Callable
 
 from xpander_sdk.models.configuration import Configuration
 from xpander_sdk.modules.events.events_module import Events
-from xpander_sdk.modules.tasks.models.task import LocalTaskTest
+from xpander_sdk.modules.tasks.models.task import LocalTaskTest, AgentExecutionInput
+from xpander_sdk.models.shared import OutputFormat
 from xpander_sdk.modules.tasks.sub_modules.task import Task
 
 
@@ -95,9 +99,12 @@ def on_task(
         if 'task' not in sig.parameters:
             raise TypeError(f"Function '{func.__name__}' must have a 'task' parameter.")
 
-        if test_task and not isinstance(test_task, LocalTaskTest):
+        # Initialize effective_test_task with the passed parameter
+        effective_test_task = test_task
+        
+        if effective_test_task and not isinstance(effective_test_task, LocalTaskTest):
             raise TypeError(
-                f"'test_task' must be an instance of LocalTaskTest, got {type(test_task).__name__}"
+                f"'test_task' must be an instance of LocalTaskTest, got {type(effective_test_task).__name__}"
             )
 
         param_names = list(sig.parameters)
@@ -136,9 +143,58 @@ def on_task(
 
         wrapped = async_wrapper if iscoroutinefunction(func) else sync_wrapper
 
+        # Check for direct invocation with --invoke and --prompt arguments
+        if any('--invoke' in arg for arg in sys.argv):
+            # Parse command line arguments
+            parser = argparse.ArgumentParser(description='Run task handler locally')
+            parser.add_argument('--invoke', action='store_true', help='Invoke the task handler directly')
+            parser.add_argument('--prompt', type=str, required='--invoke' in sys.argv, help='Input text for the task')
+            parser.add_argument('--output_format', type=str, choices=['json', 'markdown', 'text'], 
+                               help='Output format (json, markdown, text)')
+            parser.add_argument('--output_schema', type=str, help='JSON schema as a string for output validation')
+            
+            # Parse only known args to avoid conflicts with other args that might be present
+            args, _ = parser.parse_known_args()
+            
+            if args.invoke:
+                # Create a LocalTaskTest instance from command line arguments (like existing test_task logic)
+                output_format_map = {
+                    'json': OutputFormat.Json,
+                    'markdown': OutputFormat.Markdown,
+                    'text': OutputFormat.Text
+                }
+                
+                # Parse output schema if provided
+                output_schema = None
+                if args.output_schema:
+                    try:
+                        output_schema = json.loads(args.output_schema)
+                    except json.JSONDecodeError as e:
+                        print(f"Error parsing output_schema JSON: {e}")
+                        sys.exit(1)
+                
+                # Create LocalTaskTest (same as existing test_task functionality)
+                # Only include output_format and output_schema if explicitly provided
+                task_kwargs = {
+                    'input': AgentExecutionInput(text=args.prompt)
+                }
+                
+                if args.output_format:
+                    task_kwargs['output_format'] = output_format_map.get(args.output_format.lower())
+                    
+                if output_schema is not None:
+                    task_kwargs['output_schema'] = output_schema
+                
+                cli_test_task = LocalTaskTest(**task_kwargs)
+                # Override effective_test_task with CLI-provided one
+                effective_test_task = cli_test_task
+                print(f"Running task handler directly with prompt: {args.prompt}")
+                if output_schema:
+                    print(f"Using output schema: {output_schema}")
+        
         events_module = Events(configuration=configuration)
-        events_module.register(on_task=wrapped, test_task=test_task)
-
+        events_module.register(on_task=wrapped, test_task=effective_test_task)
+        
         return wrapped
 
     if _func and callable(_func):


### PR DESCRIPTION
## Overview

This PR introduces local execution support for task handlers, allowing direct invocation via CLI and SDK.  
Key changes:

- **on_task decorator**: Now parses CLI arguments (`--invoke`, `--prompt`, `--output_format`, `--output_schema`) to run handlers locally. Instantiates `LocalTaskTest` from CLI input.
- **Events module**: Improved handling for local test tasks. Prints task results to the console, exits gracefully after execution.
- **Agent worker registration**: Sets `run_locally=True` and marks the source as `SDK` for local invocations.
- Minor code cleanups and improved error messages for output schema parsing.

### Files changed

- `src/xpander_sdk/modules/backend/frameworks/agno.py`: Logic tweak for sub-agent coordination.
- `src/xpander_sdk/modules/events/decorators/on_task.py`: CLI integration for local testing, argument parsing, and handler invocation.
- `src/xpander_sdk/modules/events/events_module.py`: Task result printing and local test task flow improvements.

### Why

This enables developers to run and debug task handlers locally using CLI flags, improving the workflow for testing and validating agent logic.