### PR TITLE
feat(PRO-210): migrate xpander-sdk to Agno 2.0 and refactor agent storage/memory APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install xpander-sdk
 ### With Optional Dependencies
 
 ```bash
-# For Agno framework support
+# For Agno framework support (2.0+)
 pip install xpander-sdk[agno]
 
 # For development

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -280,7 +280,7 @@ if agent.graph and agent.graph.items:
 ```python
 # Access agent's storage backend (requires Agno framework)
 try:
-    storage = await agent.aget_storage()
+    storage = await agent.aget_db()
     print(f"Storage backend initialized: {storage}")
 
     # Example usage would depend on the storage backend API
@@ -289,25 +289,6 @@ except NotImplementedError as e:
     print(f"Storage not supported: {e}")
 except LookupError as e:
     print(f"Storage not enabled: {e}")
-```
-
-### Memory Handler Usage
-
-```python
-from your_llm_models import OpenAIModel  # Example model
-
-# Get memory handler for user memories (requires Agno framework)
-try:
-    model = OpenAIModel("gpt-4")
-    memory_handler = await agent.aget_memory_handler(model=model)
-    print(f"Memory handler initialized: {memory_handler}")
-
-    # Example usage would depend on the memory handler API
-    # Typically used for maintaining user conversation context
-except NotImplementedError as e:
-    print(f"Memory handler not supported: {e}")
-except LookupError as e:
-    print(f"User memories not enabled: {e}")
 ```
 
 ### Knowledge Base Search Integration
@@ -432,15 +413,15 @@ print(f"Output format: {agent.output_format}")
 
 |- **`attach_knowledge_base(self, knowledge_base: Optional[KnowledgeBase] = None, knowledge_base_id: Optional[str] = None)`**: Attach a knowledge base to the agent if it is not already linked.
 
-  - **Parameters**:
-    - `knowledge_base` (Optional[KnowledgeBase]): The KnowledgeBase instance to attach.
-    - `knowledge_base_id` (Optional[str]): The unique identifier of the knowledge base.
-  - **Raises**:
-    - `ValueError`: If neither a knowledge base nor an ID is provided.
-    - `TypeError`: If a provided knowledge base is not a valid `KnowledgeBase` instance.
-  - **Example**: `>>> agent.attach_knowledge_base(knowledge_base_id="kb_12345")`
+- **Parameters**:
+  - `knowledge_base` (Optional[KnowledgeBase]): The KnowledgeBase instance to attach.
+  - `knowledge_base_id` (Optional[str]): The unique identifier of the knowledge base.
+- **Raises**:
+  - `ValueError`: If neither a knowledge base nor an ID is provided.
+  - `TypeError`: If a provided knowledge base is not a valid `KnowledgeBase` instance.
+- **Example**: `>>> agent.attach_knowledge_base(knowledge_base_id="kb_12345")`
 
-  - **Note**: Changes only affect the runtime instance of the agent. To persist changes, an explicit save or sync must be called.
+- **Note**: Changes only affect the runtime instance of the agent. To persist changes, an explicit save or sync must be called.
 
 - **`async aget_knowledge_bases()`**: Get linked knowledge bases.
 
@@ -523,38 +504,20 @@ print(f"Output format: {agent.output_format}")
 
 #### Storage and Memory Methods
 
-- **`async aget_storage()`**: Asynchronously retrieve the storage backend for this agent.
+- **`async aget_db()`**: Asynchronously retrieve the storage backend for this agent.
 
   - **Description**: This method returns the storage backend for agent sessions. Only supported for agents using the Agno framework with session storage enabled.
-  - **Returns**: `PostgresStorage` - Initialized storage backend for agent sessions.
+  - **Returns**: `PostgresDb` - Initialized storage backend for agent sessions.
   - **Raises**:
     - `NotImplementedError`: If the framework does not support storage.
     - `ImportError`: If required dependencies are missing.
     - `ValueError`: If the connection string for storage is invalid.
     - `LookupError`: If session storage is not enabled for this agent.
 
-- **`get_storage()`**: Synchronously retrieve the storage backend for this agent.
+- **`get_db()`**: Synchronously retrieve the storage backend for this agent.
 
   - **Returns**: `Any` - Initialized storage backend for agent sessions.
-  - **Example**: `>>> storage = agent.get_storage()`
-
-- **`async aget_memory_handler(self, model: LLMModelT)`**: Asynchronously retrieve the memory handler backend for user memories.
-
-  - **Description**: This method returns a memory handler for managing user memories associated with the provided model. Only supported for agents using the Agno framework with user memories enabled.
-  - **Parameters**:
-    - `model` (LLMModelT): Language model type to associate with memory handler.
-  - **Returns**: `Memory` - Initialized memory handler for user memories associated with the provided model.
-  - **Raises**:
-    - `NotImplementedError`: If the framework does not support user memories.
-    - `ImportError`: If required dependencies are missing.
-    - `ValueError`: If the connection string for memory storage is invalid.
-    - `LookupError`: If user memories are not enabled for this agent.
-
-- **`get_memory_handler(self, model: LLMModelT)`**: Synchronously retrieve the memory handler backend for user memories.
-  - **Parameters**:
-    - `model` (LLMModelT): Language model type to associate with memory handler.
-  - **Returns**: `Any` - Initialized memory handler for user memories.
-  - **Example**: `>>> memory_handler = agent.get_memory_handler(model=my_model)`
+  - **Example**: `>>> storage = agent.get_db()`
 
 #### Utility Methods
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -411,17 +411,17 @@ print(f"Output format: {agent.output_format}")
 
 #### Knowledge Base Methods
 
-|- **`attach_knowledge_base(self, knowledge_base: Optional[KnowledgeBase] = None, knowledge_base_id: Optional[str] = None)`**: Attach a knowledge base to the agent if it is not already linked.
+- **`attach_knowledge_base(self, knowledge_base: Optional[KnowledgeBase] = None, knowledge_base_id: Optional[str] = None)`**: Attach a knowledge base to the agent if it is not already linked.
 
-- **Parameters**:
-  - `knowledge_base` (Optional[KnowledgeBase]): The KnowledgeBase instance to attach.
-  - `knowledge_base_id` (Optional[str]): The unique identifier of the knowledge base.
-- **Raises**:
-  - `ValueError`: If neither a knowledge base nor an ID is provided.
-  - `TypeError`: If a provided knowledge base is not a valid `KnowledgeBase` instance.
-- **Example**: `>>> agent.attach_knowledge_base(knowledge_base_id="kb_12345")`
+  - **Parameters**:
+    - `knowledge_base` (Optional[KnowledgeBase]): The KnowledgeBase instance to attach.
+    - `knowledge_base_id` (Optional[str]): The unique identifier of the knowledge base.
+  - **Raises**:
+    - `ValueError`: If neither a knowledge base nor an ID is provided.
+    - `TypeError`: If a provided knowledge base is not a valid `KnowledgeBase` instance.
+  - **Example**: `>>> agent.attach_knowledge_base(knowledge_base_id="kb_12345")`
 
-- **Note**: Changes only affect the runtime instance of the agent. To persist changes, an explicit save or sync must be called.
+  - **Note**: Changes only affect the runtime instance of the agent. To persist changes, an explicit save or sync must be called.
 
 - **`async aget_knowledge_bases()`**: Get linked knowledge bases.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ black
 pre-commit
 pytest-asyncio
 sqlalchemy
-agno<2.0
+agno
 psycopg2-binary
 nest-asyncio
 mcp

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "nest-asyncio",
     ],
     extras_require={
-        "agno": ["agno<2.0", "sqlalchemy", "psycopg2-binary"],
+        "agno": ["agno", "sqlalchemy", "psycopg2-binary"],
         "dev": ["black", "pre-commit", "pytest", "anthropic", "mcp", "openai"],
     },
     classifiers=[

--- a/src/xpander_sdk/modules/agents/models/agent.py
+++ b/src/xpander_sdk/modules/agents/models/agent.py
@@ -86,7 +86,7 @@ class AgentInstructions(BaseModel):
         return f"""
         <instructions>
             {self.role}
-        </instructions
+        </instructions>
         <goals>
             {self.goal_str}
         </goals>

--- a/src/xpander_sdk/modules/agents/models/agent.py
+++ b/src/xpander_sdk/modules/agents/models/agent.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import Dict, List, Literal, Optional, Type
 from pydantic import BaseModel, computed_field
 
-from xpander_sdk.models.shared import OutputFormat, XPanderSharedModel
+from xpander_sdk.models.shared import XPanderSharedModel
 from xpander_sdk.modules.tools_repository.models.mcp import MCPServerDetails
 
 
@@ -83,7 +83,14 @@ class AgentInstructions(BaseModel):
         Returns:
             List[str]: List of role instructions.
         """
-        return self.role
+        return f"""
+        <instructions>
+            {self.role}
+        </instructions
+        <goals>
+            {self.goal_str}
+        </goals>
+        """
 
     @computed_field
     @property

--- a/src/xpander_sdk/modules/agents/sub_modules/agent.py
+++ b/src/xpander_sdk/modules/agents/sub_modules/agent.py
@@ -558,10 +558,10 @@ class Agent(XPanderSharedModel):
 
     async def aget_db(self):
         """
-        Asynchronously retrieve the storage backend for this agent.
+        Asynchronously retrieve the db for this agent.
 
         Returns:
-            PostgresDb: Initialized storage backend (Agno PG) for agent sessions.
+            PostgresDb: Initialized db (Agno PG) for agent sessions.
 
         Raises:
             NotImplementedError: If the framework does not support storage.
@@ -580,14 +580,14 @@ class Agent(XPanderSharedModel):
             from agno.db.postgres import PostgresDb
         except ImportError as e:
             raise ImportError(
-                "The 'agno' extras must be installed to use this storage backend. "
+                "The 'agno' extras must be installed to use this db. "
                 "Run `pip install xpander-sdk[agno]`."
             ) from e
 
         connection_string = await self.aget_connection_string()
         if not connection_string or not connection_string.connection_uri.uri:
             raise ValueError(
-                "Invalid connection string provided for Agno storage backend."
+                "Invalid connection string provided for Agno db."
             )
 
         schema = get_db_schema_name(agent_id=self.id)
@@ -599,13 +599,13 @@ class Agent(XPanderSharedModel):
 
     def get_db(self) -> Any:
         """
-        Synchronously retrieve the storage backend for this agent.
+        Synchronously retrieve the db for this agent.
 
         Returns:
-            Any: Initialized storage backend for agent sessions.
+            Any: Initialized db for agent sessions.
 
         Example:
-            >>> storage = agent.get_storage()
+            >>> db = agent.get_db()
         """
         return run_sync(self.aget_db())
 
@@ -696,7 +696,7 @@ class Agent(XPanderSharedModel):
         Asynchronously retrieve all user sessions associated with this agent.
 
         This method loads all saved session records linked to the specified user ID from
-        the agent's storage backend. It is only supported for agents using the Agno framework
+        the agent's db. It is only supported for agents using the Agno framework
         with session storage enabled.
 
         Args:
@@ -724,7 +724,7 @@ class Agent(XPanderSharedModel):
         Synchronously retrieve all user sessions associated with this agent.
 
         This method wraps the asynchronous `aget_user_sessions` method and returns the result
-        in a synchronous context. It loads session data for a given user ID from the agent's storage backend.
+        in a synchronous context. It loads session data for a given user ID from the agent's db.
 
         Args:
             user_id (str): Identifier of the user whose sessions are to be retrieved.
@@ -741,7 +741,7 @@ class Agent(XPanderSharedModel):
         """
         Asynchronously retrieve a single session by its session ID.
 
-        This method accesses the agent's storage backend and loads the session record
+        This method accesses the agent's db and loads the session record
         corresponding to the given session ID. It is only supported for agents using
         the Agno framework with session storage enabled.
 
@@ -771,7 +771,7 @@ class Agent(XPanderSharedModel):
 
         This method wraps the asynchronous `aget_session` and returns the result
         in a synchronous context. It retrieves the session record from the agent's
-        storage backend using the given session ID.
+        db using the given session ID.
 
         Args:
             session_id (str): Unique identifier of the session to retrieve.
@@ -788,7 +788,7 @@ class Agent(XPanderSharedModel):
         """
         Asynchronously delete a session by its session ID.
 
-        This method removes a specific session record from the agent's storage backend
+        This method removes a specific session record from the agent's db
         based on the provided session ID. It is only supported for agents using the
         Agno framework with session storage enabled.
 
@@ -812,7 +812,7 @@ class Agent(XPanderSharedModel):
         Synchronously delete a session by its session ID.
 
         This method wraps the asynchronous `adelete_session` and removes the session
-        record from the agent's storage backend in a synchronous context.
+        record from the agent's db in a synchronous context.
 
         Args:
             session_id (str): Unique identifier of the session to delete.


### PR DESCRIPTION
## Overview

This PR migrates the xpander-sdk to support Agno 2.0, refactoring agent storage and memory APIs for improved consistency and maintainability.

## Key Changes

- **Agno 2.0 Migration:** Updated dependencies and codebase to use Agno 2.0, removing version pinning and legacy API usage.
- **Agent Storage Refactor:**  
  - Replaced all references to `aget_storage`/`get_storage` with `aget_db`/`get_db`.
  - Updated storage backend from `PostgresStorage` to `PostgresDb`.
  - Adjusted session and user session management to use new Agno DB APIs.
- **Memory Handler Removal:**  
  - Removed async/sync memory handler methods and related documentation.
  - Updated documentation to reflect new storage and memory access patterns.
- **API and Docs Updates:**  
  - Updated `AGENTS.md` to document new async/sync storage methods and removed memory handler sections.
  - Updated `README.md` to clarify Agno 2.0+ support.
- **Dependency Updates:**  
  - Removed version pinning for Agno in `requirements.txt` and `setup.py`.
  - Cleaned up extras and development dependencies.

## Motivation

- Aligns xpander-sdk with the latest Agno 2.0 framework.
- Simplifies agent storage and memory management.
- Reduces technical debt by removing deprecated APIs and documentation.

## Breaking Changes

- **API:**  
  - `aget_storage`/`get_storage` replaced by `aget_db`/`get_db`.
  - Memory handler APIs removed.
- **Dependencies:**  
  - Requires Agno 2.0+.

## Related Commits

- `feat(PRO-210): migrate to Agno 2.0` ([[6947b6c](url://45)](url://45), [[fc87033](url://48)](url://48))

---

Please review for compatibility and let me know if further adjustments are needed.