### PR TITLE
feat(PRO-265): add internal_status to task models and propagate to metrics

### DIFF
--- a/src/xpander_sdk/modules/tasks/models/task.py
+++ b/src/xpander_sdk/modules/tasks/models/task.py
@@ -158,6 +158,7 @@ class ExecutionMetricsReport(XPanderSharedModel):
     triggered_by: Optional[str] = "N/A"
     skills: Optional[list[str]] = []
     status: str
+    internal_status: Optional[str] = None
     duration: float
     ai_model: str
     worker: Optional[str] = None

--- a/src/xpander_sdk/modules/tasks/sub_modules/task.py
+++ b/src/xpander_sdk/modules/tasks/sub_modules/task.py
@@ -125,6 +125,7 @@ class Task(XPanderSharedModel):
     organization_id: str
     input: AgentExecutionInput
     status: Optional[AgentExecutionStatus] = AgentExecutionStatus.Pending
+    internal_status: Optional[str] = None
     last_executed_node_id: Optional[str] = None
     agent_version: Optional[str] = None
     created_at: datetime
@@ -605,6 +606,7 @@ class Task(XPanderSharedModel):
                 memory_thread_id=self.id,
                 task=self.input.text or "",
                 status=self.status.value,
+                internal_status=self.internal_status,
                 duration=0.0,
                 ai_model="xpander",
                 api_calls_made=self.used_tools,


### PR DESCRIPTION
## Purpose
Introduce an optional internal status field for tasks to capture granular execution state and ensure it is reported in metrics for observability and debugging.

## Key changes
- Added `internal_status: Optional[str] = None` to `ExecutionMetricsReport` in `src/xpander_sdk/modules/tasks/models/task.py`
- Added `internal_status: Optional[str] = None` to `Task` in `src/xpander_sdk/modules/tasks/sub_modules/task.py`
- Propagated `internal_status` into `areport_metrics(...)` payload so metrics include this field

## Notes
- No database migrations indicated (model changes are in-code only)
- Backward compatible: `internal_status` is optional and defaults to `None`
- Improves diagnostics without affecting public API behavior

## Testing
- Manual: run a task with varied internal states and verify metrics include `internal_status`
- Ensure tasks without `internal_status` still report successfully

## Follow-ups
- Consider enum-typing `internal_status` for consistency and validation
- Add unit tests around metrics reporting with/without `internal_status`
