### PR TITLE
feat(PRO-328): add FireworksAI provider and configurable LLM API base across Agno backend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ mcp
 openai
 anthropic
 packaging
+fireworks-ai

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     extras_require={
         "agno": ["agno", "sqlalchemy", "psycopg2-binary"],
-        "dev": ["black", "pre-commit", "pytest", "anthropic", "mcp", "openai"],
+        "dev": ["black", "pre-commit", "pytest", "anthropic", "mcp", "openai", "fireworks-ai"],
     },
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/src/xpander_sdk/modules/agents/sub_modules/agent.py
+++ b/src/xpander_sdk/modules/agents/sub_modules/agent.py
@@ -147,6 +147,7 @@ class Agent(XPanderSharedModel):
             using_nemo: Optional[bool]
             model_provider: str
             model_name: str
+            llm_api_base: Optional[str]
             webhook_url: Optional[str]
             created_at: Optional[datetime]
             type: Optional[AgentType]
@@ -185,6 +186,7 @@ class Agent(XPanderSharedModel):
     using_nemo: Optional[bool] = False
     model_provider: str
     model_name: str
+    llm_api_base: Optional[str] = None
     webhook_url: Optional[str] = None
     created_at: Optional[datetime] = None
     type: Optional[AgentType] = None


### PR DESCRIPTION
## Purpose
Enable FireworksAI as an LLM provider in our Agno backend and introduce a configurable `llm_api_base` for agents, allowing custom endpoints (e.g., self-hosted gateways or vendor-specific bases).

## Key changes
- Dependencies: added `fireworks-ai` to `requirements.txt` and `setup.py` (dev extras)
- Agent model: added optional `llm_api_base` field (Pydantic) with default `None`
- Agno framework:
  - Inject `base_url` into model construction when `agent.llm_api_base` is provided
  - Implement Fireworks provider via `agno.models.fireworks.Fireworks` using `FIREWORKS_API_KEY`
  - Normalize Nvidia NIM init to support `**llm_args` and maintain temperature setting
  - Preserve OpenAI provider behavior with dual API key fallback

## Notes
- Config: set `FIREWORKS_API_KEY` in environment for Fireworks provider
- Backward compatibility: agents without `llm_api_base` continue to use default endpoints
- Risk: misconfigured `llm_api_base` can route requests to non-responsive or throttled endpoints; monitor errors and timeouts
- Performance: custom bases may change latency characteristics depending on network path

## Testing
- Manual: create an agent with `model_provider="fireworks"` and valid `model_name`, set `FIREWORKS_API_KEY`, verify completions
- Manual: set `llm_api_base` for OpenAI/NIM providers and confirm requests hit the configured base URL
- Unit: add provider initialization tests ensuring `base_url` is passed when `llm_api_base` is set

## Follow-ups
- PRO-328: document supported Fireworks model IDs and recommended base URLs
- Add integration tests for multiple providers with `llm_api_base` overrides
