### PR TITLE
feat(PRO-376): migrate agents to AsyncPostgresDb and psycopg async driver

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -525,7 +525,7 @@ elif agent.deployment_type == AgentDeploymentType.Container:
 - **`async aget_db()`**: Asynchronously retrieve the storage backend for this agent.
 
   - **Description**: This method returns the storage backend for agent sessions. Only supported for agents using the Agno framework with session storage enabled.
-  - **Returns**: `PostgresDb` - Initialized storage backend for agent sessions.
+  - **Returns**: `AsyncPostgresDb` - Initialized storage backend for agent sessions.
   - **Raises**:
     - `NotImplementedError`: If the framework does not support storage.
     - `ImportError`: If required dependencies are missing.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -110,7 +110,7 @@ result = weather_tool.invoke(
 if tools_repo.should_sync_local_tools():
     local_tools = tools_repo.get_local_tools_for_sync()
     print(f"Found {len(local_tools)} tools to sync")
-    
+
     for tool in local_tools:
         print(f"Syncing tool: {tool.name}")
         # Sync logic would be handled by the platform
@@ -138,57 +138,65 @@ mcp_server = MCPServerDetails(
 ### `ToolsRepository`
 
 - **`register_tool(cls, tool: Tool)`**: Register a local tool (class method)
-    - **Parameters**: `tool` (Tool): The tool instance to register
-    - **Returns**: None
-    - **Description**: Adds a tool to the local tools registry for later use.
+
+  - **Parameters**: `tool` (Tool): The tool instance to register
+  - **Returns**: None
+  - **Description**: Adds a tool to the local tools registry for later use.
 
 - **`get_tool_by_id(self, tool_id: str) -> Tool`**: Get tool by ID
-    - **Parameters**: `tool_id` (str): Unique identifier of the tool
-    - **Returns**: Tool instance corresponding to the given ID
-    - **Description**: Retrieves a tool from the combined list of backend and local tools.
+
+  - **Parameters**: `tool_id` (str): Unique identifier of the tool
+  - **Returns**: Tool instance corresponding to the given ID
+  - **Description**: Retrieves a tool from the combined list of backend and local tools.
 
 - **`should_sync_local_tools(self) -> bool`**: Check sync requirements
-    - **Returns**: bool indicating if any local tools need syncing with the backend
-    - **Description**: Determines if local tools marked for graph addition need synchronization.
+
+  - **Returns**: bool indicating if any local tools need syncing with the backend
+  - **Description**: Determines if local tools marked for graph addition need synchronization.
 
 - **`get_local_tools_for_sync(self) -> List[Tool]`**: Get tools needing sync
-    - **Returns**: List of local tools marked for graph addition that are not yet synced
-    - **Description**: Retrieves local tools that require synchronization with the backend.
+
+  - **Returns**: List of local tools marked for graph addition that are not yet synced
+  - **Description**: Retrieves local tools that require synchronization with the backend.
 
 - **`list (property) -> List[Tool]`**: Return all available tools
-    - **Returns**: List of all tools (both backend-managed and locally registered)
-    - **Description**: Merges backend tools and local tools, ensuring no duplicates by ID.
+
+  - **Returns**: List of all tools (both backend-managed and locally registered)
+  - **Description**: Merges backend tools and local tools, ensuring no duplicates by ID.
 
 - **`functions (property) -> List[Callable[..., Any]]`**: Get normalized callable functions
-    - **Returns**: List of callable functions corresponding to each registered tool
-    - **Description**: Provides schema-validated callable functions for direct execution.
+  - **Returns**: List of callable functions corresponding to each registered tool
+  - **Description**: Provides schema-validated callable functions for direct execution.
 
 ### `Tool`
 
 - **`async ainvoke(self, agent_id: str, payload: Any, payload_extension: Optional[Dict[str, Any]] = {}, configuration: Optional[Configuration] = None, task_id: Optional[str] = None, tool_call_id: Optional[str] = None) -> ToolInvocationResult`**: Asynchronously invoke the tool (local or remote), with schema validation and error handling.
-    - **Parameters**: 
-        - `agent_id` (str): ID of the agent making the call
-        - `payload` (Any): The input payload to the tool
-        - `payload_extension` (Optional[Dict[str, Any]]): Optional additional payload data
-        - `configuration` (Optional[Configuration]): Optional configuration override
-        - `task_id` (Optional[str]): ID of the current task context
-        - `tool_call_id` (Optional[str]): Unique ID of the tool call
-    - **Returns**: ToolInvocationResult - Result object encapsulating invocation output and status
-    - **Description**: Main method for invoking tools with full validation and error handling.
+
+  - **Parameters**:
+    - `agent_id` (str): ID of the agent making the call
+    - `payload` (Any): The input payload to the tool
+    - `payload_extension` (Optional[Dict[str, Any]]): Optional additional payload data
+    - `configuration` (Optional[Configuration]): Optional configuration override
+    - `task_id` (Optional[str]): ID of the current task context
+    - `tool_call_id` (Optional[str]): Unique ID of the tool call
+  - **Returns**: ToolInvocationResult - Result object encapsulating invocation output and status
+  - **Description**: Main method for invoking tools with full validation and error handling.
 
 - **`invoke(self, agent_id: str, payload: Any, payload_extension: Optional[Dict[str, Any]] = {}, configuration: Optional[Configuration] = None, task_id: Optional[str] = None, tool_call_id: Optional[str] = None) -> ToolInvocationResult`**: Synchronous wrapper for `ainvoke`.
-    - **Parameters**: Same as `ainvoke`
-    - **Returns**: ToolInvocationResult - Result of the tool invocation
-    - **Description**: Synchronous version of tool invocation for non-async environments.
+
+  - **Parameters**: Same as `ainvoke`
+  - **Returns**: ToolInvocationResult - Result of the tool invocation
+  - **Description**: Synchronous version of tool invocation for non-async environments.
 
 - **`set_configuration(self, configuration: Configuration)`**: Set the configuration object for this tool.
-    - **Parameters**: `configuration` (Configuration): The configuration instance to associate with this tool
-    - **Returns**: None
-    - **Description**: Updates the tool's configuration for API communication.
+
+  - **Parameters**: `configuration` (Configuration): The configuration instance to associate with this tool
+  - **Returns**: None
+  - **Description**: Updates the tool's configuration for API communication.
 
 - **`schema (property) -> type[BaseModel]`**: Generate Pydantic model schema
-    - **Returns**: A dynamically constructed Pydantic model class based on tool parameters
-    - **Description**: Provides schema validation for tool payloads.
+  - **Returns**: A dynamically constructed Pydantic model class based on tool parameters
+  - **Description**: Provides schema validation for tool payloads.
 
 ### `@register_tool` Decorator
 
@@ -211,9 +219,11 @@ def tool_function(param1: type, param2: type = default) -> return_type:
 ```
 
 **Parameters:**
+
 - `add_to_graph` (Optional[bool]): Whether to automatically add this tool to agent execution graphs. Defaults to False.
 
 **Behavior:**
+
 - Tool name is automatically derived from the function name
 - Tool description is extracted from the function's docstring
 - Function parameters and type hints are used to generate the tool schema
@@ -301,7 +311,7 @@ class CustomTool(Tool):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # Custom initialization
-    
+
     async def custom_method(self):
         # Custom functionality
         pass
@@ -344,13 +354,13 @@ def call_api_endpoint(endpoint: str, method: str = "GET") -> dict:
 ### Database Integration
 
 ```python
-import asyncpg
+import psycopg
 from xpander_sdk import register_tool
 
 @register_tool
 async def query_database(query: str, params: list = None) -> list:
     """Execute a database query."""
-    conn = await asyncpg.connect("postgresql://...")
+    conn = await psycopg.connect("postgresql://...")
     try:
         result = await conn.fetch(query, *(params or []))
         return [dict(row) for row in result]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,10 @@ pytest
 black
 pre-commit
 pytest-asyncio
-sqlalchemy
 agno
-psycopg2-binary
+sqlalchemy
+psycopg
+greenlet
 nest-asyncio
 mcp
 openai

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "nest-asyncio",
     ],
     extras_require={
-        "agno": ["agno", "sqlalchemy", "psycopg2-binary"],
+        "agno": ["agno", "sqlalchemy" ,"psycopg", "greenlet"],
         "dev": ["black", "pre-commit", "pytest", "anthropic", "mcp", "openai", "fireworks-ai"],
     },
     classifiers=[

--- a/src/xpander_sdk/modules/agents/sub_modules/agent.py
+++ b/src/xpander_sdk/modules/agents/sub_modules/agent.py
@@ -573,7 +573,7 @@ class Agent(XPanderSharedModel):
         Asynchronously retrieve the db for this agent.
 
         Returns:
-            PostgresDb: Initialized db (Agno PG) for agent sessions.
+            AsyncPostgresDb: Initialized async db (Agno PG) for agent sessions.
 
         Raises:
             NotImplementedError: If the framework does not support storage.
@@ -589,7 +589,7 @@ class Agent(XPanderSharedModel):
             raise LookupError("Session storage is not enabled for this agent.")
 
         try:
-            from agno.db.postgres import PostgresDb
+            from agno.db.postgres import AsyncPostgresDb
         except ImportError as e:
             raise ImportError(
                 "The 'agno' extras must be installed to use this db. "
@@ -604,9 +604,9 @@ class Agent(XPanderSharedModel):
 
         schema = get_db_schema_name(agent_id=self.id)
 
-        return PostgresDb(
+        return AsyncPostgresDb(
             db_schema=schema,
-            db_url=connection_string.connection_uri.uri,
+            db_url=connection_string.connection_uri.uri.replace("postgresql", "postgresql+psycopg_async"),
         )
 
     def get_db(self) -> Any:


### PR DESCRIPTION
## Purpose
Move agent session storage to an async PostgreSQL stack to improve concurrency and reduce blocking I/O during tool and agent operations.

## Key changes
- Switched agent DB helper from `PostgresDb` to `AsyncPostgresDb` in `agent.py`.
- Updated connection URI to use async driver: replace `postgresql` with `postgresql+psycopg_async`.
- Documentation updates:
  - AGENTS.md: return type now `AsyncPostgresDb`.
  - TOOLS.md: expanded repository and tool invocation docs; adjusted DB integration example from `asyncpg` to `psycopg`.
- Dependencies:
  - requirements: add `psycopg`, keep `sqlalchemy`, remove `psycopg2-binary`.
  - setup extras: `agno` extra now uses `psycopg` + `greenlet`.
- Minor doc deduplication and clarifications in tools repository sections.

## Notes
- This is a runtime behavior change: agents now rely on async DB operations.
- Ensure environment connection strings are compatible with `psycopg` async.
- Potential impact on any synchronous code paths calling DB helpers; prefer `ainvoke`/async flows.
- Able to merge automatically per comparison page.

## Testing
- Run agent flows that require session storage and verify async paths:
  1. Start an agent with Agno session storage enabled.
  2. Execute tool calls and confirm non-blocking behavior under load.
  3. Validate schema creation uses the same `get_db_schema_name(agent_id)` value.
- If present, run pytest with `pytest-asyncio` to cover async DB interactions.

## Follow-ups
- Audit any remaining `PostgresDb` references across the codebase.
- Add integration tests for connection failures and reconnection with async driver.
- Consider migration notes in platform docs for self-hosted deployments.
