### PR TITLE
fix(PRO-385): support async/sync Postgres clients and propagate async context

### DIFF
--- a/src/xpander_sdk/modules/backend/backend_module.py
+++ b/src/xpander_sdk/modules/backend/backend_module.py
@@ -230,6 +230,7 @@ class Backend(ModuleBase):
         task: Optional[Task] = None,
         override: Optional[Dict[str, Any]] = None,
         tools: Optional[List[Callable]] = None,
+        is_async: Optional[bool] = True
     ) -> Dict[str, Any]:
         """
         Asynchronously resolve runtime arguments for the specified agent.
@@ -241,6 +242,7 @@ class Backend(ModuleBase):
             task (Optional[Task]): Optional Task object providing runtime input/output context.
             override (Optional[Dict[str, Any]]): Optional overrides for final arguments.
             tools (Optional[List[Callable]]): Optional additional tools to be added to the agent arguments.
+            is_async (Optional[bool]): Is in Async Context?.
 
         Returns:
             Dict[str, Any]: Resolved argument dictionary to use with the agent.
@@ -265,7 +267,7 @@ class Backend(ModuleBase):
                 "or set via the 'XPANDER_AGENT_ID' environment variable."
             )
 
-        return await dispatch_get_args(agent=xpander_agent, task=task, override=override, tools=tools)
+        return await dispatch_get_args(agent=xpander_agent, task=task, override=override, tools=tools, is_async=is_async)
 
     def get_args(
         self,
@@ -303,7 +305,8 @@ class Backend(ModuleBase):
                 agent_version=agent_version,
                 task=task,
                 override=override,
-                tools=tools
+                tools=tools,
+                is_async=False
             )
         )
     

--- a/src/xpander_sdk/modules/backend/frameworks/agno.py
+++ b/src/xpander_sdk/modules/backend/frameworks/agno.py
@@ -28,6 +28,7 @@ async def build_agent_args(
     task: Optional[Task] = None,
     override: Optional[Dict[str, Any]] = None,
     tools: Optional[List[Callable]] = None,
+    is_async: Optional[bool] = True
 ) -> Dict[str, Any]:
     model = _load_llm_model(agent=xpander_agent, override=override)
     args: Dict[str, Any] = {
@@ -38,7 +39,7 @@ async def build_agent_args(
     _configure_session_storage(args=args, agent=xpander_agent, task=task)
     _configure_user_memory(args=args, agent=xpander_agent, task=task)
     await _attach_async_dependencies(
-        args=args, agent=xpander_agent, task=task, model=model
+        args=args, agent=xpander_agent, task=task, model=model, is_async=is_async
     )
     _configure_knowledge_bases(args=args, agent=xpander_agent)
     _configure_additional_context(args=args, agent=xpander_agent, task=task)
@@ -339,12 +340,12 @@ def _configure_user_memory(
 
 
 async def _attach_async_dependencies(
-    args: Dict[str, Any], agent: Agent, task: Optional[Task], model: Any
+    args: Dict[str, Any], agent: Agent, task: Optional[Task], model: Any, is_async: Optional[bool] = True
 ) -> None:
     user = task.input.user if task and task.input and task.input.user else None
     should_use_users_memory = True if agent.agno_settings.user_memories and user and user.id else False
     if agent.agno_settings.session_storage or should_use_users_memory:
-        args["db"] = await agent.aget_db()
+        args["db"] = await agent.aget_db(async_db=is_async)
 
 def _configure_knowledge_bases(args: Dict[str, Any], agent: Agent) -> None:
     if agent.knowledge_bases:

--- a/src/xpander_sdk/modules/backend/frameworks/dispatch.py
+++ b/src/xpander_sdk/modules/backend/frameworks/dispatch.py
@@ -9,6 +9,7 @@ async def dispatch_get_args(
     task: Optional[Task] = None,
     override: Optional[Dict[str, Any]] = None,
     tools: Optional[List[Callable]] = None,
+    is_async: Optional[bool] = True
 ) -> Dict[str, Any]:
     """
     Dispatch to the correct framework-specific argument resolver.
@@ -18,6 +19,7 @@ async def dispatch_get_args(
         task (Optional[Task]): Optional runtime task.
         override (Optional[Dict[str, Any]]): Dict of override values.
         tools (Optional[List[Callable]]): Optional additional tools to be added to the agent arguments.
+        is_async (Optional[bool]): Is in Async Context?.
 
     Returns:
         Dict[str, Any]: Arguments for instantiating the framework agent.
@@ -25,7 +27,7 @@ async def dispatch_get_args(
     match agent.framework:
         case Framework.Agno:
             from .agno import build_agent_args
-            return await build_agent_args(xpander_agent=agent, task=task, override=override, tools=tools)
+            return await build_agent_args(xpander_agent=agent, task=task, override=override, tools=tools, is_async=is_async)
         # case Framework.Langchain: # PLACEHOLDER
         #     from .langchain import build_agent_args
         #     return await build_agent_args(xpander_agent=agent, task=task, override=override)


### PR DESCRIPTION
## Purpose
Ensure agents can operate with both asynchronous and synchronous PostgreSQL clients and correctly propagate async context through backend argument resolution.

## Key changes
- Agent: `aget_db(async_db: bool = True)` now returns `AsyncPostgresDb` or `PostgresDb` based on flag.
- Agent: `get_db()` explicitly uses sync client via `aget_db(async_db=False)`.
- Agent: DB URL construction switches driver to `postgresql+psycopg[_async]` dynamically.
- Backend: Threaded `is_async` parameter across `BackendModule.aget_args` and `get_args`.
- Dispatch: Added `is_async` propagation into framework-specific builders.
- Agno framework: `_attach_async_dependencies` requests DB using the `is_async` flag; `build_agent_args` accepts and forwards `is_async`.

## Notes
- No schema changes; connection string driver changes may affect connection pooling and SQLAlchemy engine initialization.
- Requires `agno` extras providing both `AsyncPostgresDb` and `PostgresDb`.
- Session storage and user memory features now respect async context, reducing event loop misuse.
- Backward compatibility: default behavior remains async unless `get_args(..., is_async=False)` or `get_db()` is used.

## Testing
- Manual: 
  - Instantiate agent with session storage enabled; verify async path returns `AsyncPostgresDb`.
  - Call `get_db()` from sync context and confirm `PostgresDb` is used.
  - Validate connection URLs switch between `postgresql+psycopg_async` and `postgresql+psycopg`.
- Integration:
  - Run a task via `BackendModule.get_args(is_async=False)` and ensure DB ops execute without asyncio warnings.
  - Run a task via `BackendModule.aget_args(is_async=True)` and confirm async queries succeed.

## Follow-ups
- PRO-376: audit all database call sites to remove implicit async usage in sync flows.
- Add unit tests for `aget_db` URL formatting and client type selection.
- Document configuration flags for async/sync selection across SDK.
