### PR TITLE
feat(PRO-434): add task-level control to disable attachment injection for fetched URLs

### DIFF
--- a/src/xpander_sdk/modules/tasks/sub_modules/task.py
+++ b/src/xpander_sdk/modules/tasks/sub_modules/task.py
@@ -398,6 +398,7 @@ class Task(XPanderSharedModel):
             ...     files=files
             ... )
         """
+        
         if not self.input.files or len(self.input.files) == 0:
             return []
         
@@ -471,7 +472,7 @@ class Task(XPanderSharedModel):
         if not categorized_files.files or len(categorized_files.files) == 0:
             return []
 
-        return run_sync(fetch_urls(urls=categorized_files.files))
+        return run_sync(fetch_urls(urls=categorized_files.files, disable_attachment_injection=self.disable_attachment_injection))
     
     def to_message(self) -> str:
         """

--- a/src/xpander_sdk/modules/tasks/utils/files.py
+++ b/src/xpander_sdk/modules/tasks/utils/files.py
@@ -1,6 +1,6 @@
 import base64
 import mimetypes
-from typing import List
+from typing import List, Optional
 from urllib.parse import urlparse
 import os
 from pydantic import BaseModel
@@ -47,7 +47,7 @@ def categorize_files(file_urls: list[str]) -> FileCategorization:
 
     return FileCategorization(**result)
 
-async def fetch_urls(urls: list[str]) -> list[dict[str, str]]:
+async def fetch_urls(urls: list[str], disable_attachment_injection: Optional[bool] = False) -> list[dict[str, str]]:
     """
     Fetches the content of multiple URLs asynchronously.
 
@@ -57,9 +57,12 @@ async def fetch_urls(urls: list[str]) -> list[dict[str, str]]:
     Returns:
         list[dict[str, str]]: A list of dictionaries containing the URL and its content.
                               Example: [{"url": "...", "content": "..."}]
+        disable_attachment_injection (Optional[bool]): Optional selection if to disable attachment injection to the context window.
     """
     async def fetch(client: httpx.AsyncClient, url: str) -> dict[str, str]:
         try:
+            if disable_attachment_injection:
+                return {"url": url}
             response = await client.get(url, timeout=10.0)
             response.raise_for_status()
             return {"url": url, "content": response.text}


### PR DESCRIPTION
## Purpose
Introduce a per-task switch to **disable attachment injection** when fetching URLs, allowing tasks to skip loading remote content into the context window for performance, safety, or policy reasons.

## Key changes
- Added `disable_attachment_injection` flag on `Task` (default: False)
- Extended `fetch_urls(urls, disable_attachment_injection)` to accept optional flag
- Short-circuit in `fetch_urls` to return only URL metadata when disabled (no HTTP GET, no content)
- Updated `get_human_readable_files()` to pass task flag into `fetch_urls`

## Notes
- Default behavior remains unchanged (injection enabled)
- When disabled, downstream consumers receive `{ "url": ... }` without `content`
- Reduces network calls and context window usage; helps avoid unintended content ingestion
- Ensure callers can handle absent `content` in results

## Testing
- Unit: add tests covering both modes (enabled/disabled) to verify:
  - Disabled: no network requests, returns URL-only dicts
  - Enabled: performs HTTP GET and returns `content`
- Manual: run a task with `disable_attachment_injection=True` and confirm faster execution and no content payloads

## Follow-ups
- PRO-XXX: propagate flag through higher-level task pipelines and UI configuration
- Document contract for consumers expecting `content` field when injection is enabled
