### PR TITLE
feat(PRO-440): add Google AI Studio (Gemini) provider to Agno and dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ openai
 anthropic
 packaging
 fireworks-ai
+google-genai

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     extras_require={
         "agno": ["agno", "sqlalchemy" ,"psycopg[binary,pool]", "greenlet"],
-        "dev": ["black", "pre-commit", "pytest", "anthropic", "mcp", "openai", "fireworks-ai", "aioboto3"],
+        "dev": ["black", "pre-commit", "pytest", "anthropic", "mcp", "openai", "fireworks-ai", "aioboto3", "google-genai"],
     },
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/src/xpander_sdk/modules/backend/frameworks/agno.py
+++ b/src/xpander_sdk/modules/backend/frameworks/agno.py
@@ -244,7 +244,7 @@ def _load_llm_model(agent: Agent, override: Optional[Dict[str, Any]]) -> Any:
     """
     if override and "model" in override:
         return override["model"]
-
+    
     provider = agent.model_provider.lower()
 
     is_xpander_cloud = getenv("IS_XPANDER_CLOUD", "false") == "true"
@@ -289,6 +289,16 @@ def _load_llm_model(agent: Agent, override: Optional[Dict[str, Any]]) -> Any:
             api_key=get_llm_key("AGENTS_OPENAI_API_KEY")
             or get_llm_key("OPENAI_API_KEY"),
             temperature=0.0,
+            **llm_args
+        )
+    # Google AI Studio - supports gemini models
+    elif provider == "google_ai_studio":
+        from agno.models.google import Gemini
+
+        return Gemini(
+            id=agent.model_name,
+            # Try xpander.ai-specific key first, fallback to standard OpenAI key
+            api_key=get_llm_key("GOOGLE_API_KEY"),
             **llm_args
         )
     # Fireworks AI Provider


### PR DESCRIPTION
## Purpose
Enable agents to use Google AI Studio (Gemini) via the Agno framework, expanding supported LLM providers for xpander-sdk.

## Key changes
- requirements.txt: add `google-genai` dependency
- setup.py (dev extras): include `google-genai` for local development
- agno.py: introduce `google_ai_studio` provider branch using `agno.models.google.Gemini`, wiring `id=agent.model_name`, `api_key=get_llm_key("GOOGLE_API_KEY")`, and `**llm_args`

## Notes
- Requires environment variable `GOOGLE_API_KEY` to be present in runtime/secrets
- Default `temperature=0.0` is maintained via shared `llm_args`
- Backward-compatible: existing providers (OpenAI, Anthropic, Fireworks, etc.) unchanged

## Testing
- Manual: set `agent.model_provider="google_ai_studio"` and a valid `agent.model_name` (e.g., a Gemini model); verify responses with `GOOGLE_API_KEY` configured
- Unit (suggested): add tests covering provider selection, key resolution via `get_llm_key`, and basic prompt execution path

## Follow-ups
- Document supported Gemini model IDs and recommended defaults
- Add CI integration test with a mocked Google client
- Update user-facing configuration guides to include `GOOGLE_API_KEY`
