### PR TITLE
feat(PRO-451): add Agno tool call compression settings and wiring

### DIFF
--- a/src/xpander_sdk/models/frameworks.py
+++ b/src/xpander_sdk/models/frameworks.py
@@ -17,6 +17,10 @@ class Framework(str, Enum):
     OpenAIAgents = "open-ai-agents"
     Strands = "strands-agents"
 
+class AgnoToolCallsCompressionSettings(BaseModel):
+    enabled: Optional[bool] = False
+    threshold: Optional[int] = 3
+    instructions: Optional[str] = ""
 
 class AgnoSettings(BaseModel):
     """
@@ -50,3 +54,5 @@ class AgnoSettings(BaseModel):
     openai_moderation_enabled: Optional[bool] = False
     openai_moderation_categories: Optional[List[str]] = None
     reasoning_tools_enabled: Optional[bool] = False
+    
+    tool_calls_compression: Optional[AgnoToolCallsCompressionSettings] = None

--- a/src/xpander_sdk/modules/backend/frameworks/agno.py
+++ b/src/xpander_sdk/modules/backend/frameworks/agno.py
@@ -44,6 +44,7 @@ async def build_agent_args(
     _configure_output(args=args, agent=xpander_agent, task=task)
     _configure_session_storage(args=args, agent=xpander_agent, task=task)
     _configure_user_memory(args=args, agent=xpander_agent, task=task)
+    _configure_tool_calls_compression(args=args, agent=xpander_agent)
     await _attach_async_dependencies(
         args=args, agent=xpander_agent, task=task, model=model, is_async=is_async
     )
@@ -416,6 +417,17 @@ def _configure_session_storage(
     if agent.agno_settings.max_tool_calls_from_history and agent.agno_settings.max_tool_calls_from_history >= 1:
         args["max_tool_calls_from_history"] = agent.agno_settings.max_tool_calls_from_history
 
+
+def _configure_tool_calls_compression(
+    args: Dict[str, Any], agent: Agent
+) -> None:
+    if agent.agno_settings.tool_calls_compression and agent.agno_settings.tool_calls_compression.enabled:
+        from agno.compression.manager import CompressionManager
+        args["compression_manager"] = CompressionManager(
+            compress_tool_results=True,
+            compress_tool_results_limit=agent.agno_settings.tool_calls_compression.threshold,
+            compress_tool_call_instructions=agent.agno_settings.tool_calls_compression.instructions,
+        )
 
 def _configure_user_memory(
     args: Dict[str, Any], agent: Agent, task: Optional[Task]


### PR DESCRIPTION
## Purpose
Reduce payload size and improve reviewability of agent tool interactions by enabling configurable compression of tool call results and instructions within the Agno framework integration.

## Key changes
- Added `AgnoToolCallsCompressionSettings` (enabled, threshold, instructions) to `AgnoSettings`
- Introduced `tool_calls_compression` field in `AgnoSettings` to control compression behavior
- Wired `_configure_tool_calls_compression` into `build_agent_args` flow
- When enabled, sets `CompressionManager` with:
  - `compress_tool_results=True`
  - `compress_tool_results_limit` from `threshold`
  - `compress_tool_call_instructions` from `instructions`

## Notes
- Default is disabled (`enabled=False`), no behavior change unless configured
- Compression thresholds may affect downstream consumers expecting full tool outputs
- No database changes, config-only feature
- Requires `agno.compression.manager` to be available at runtime

## Testing
- Manual: validate args include `compression_manager` when `enabled=True`
- Manual: verify tool results are truncated based on `threshold`
- Manual: confirm no compression applied when disabled

## Follow-ups
- PRO-451: add unit/integration tests for CompressionManager wiring
- Document recommended thresholds per agent type
- Add observability counters for compressed vs. raw tool results

## Screenshots
<!-- Paste screenshots here if applicable -->
