### PR TITLE
feat(PRO-452): add A2A and curl agent types with connectivity details

### DIFF
--- a/src/xpander_sdk/modules/agents/models/agent.py
+++ b/src/xpander_sdk/modules/agents/models/agent.py
@@ -395,6 +395,7 @@ class AIAgentConnectivityDetailsBase(XPanderSharedModel):
     custom_headers: Optional[Dict[str, str]] = {}
     auth_type: Optional[AIAgentConnectivityDetailsA2AAuthType] = AIAgentConnectivityDetailsA2AAuthType.NoAuth
     api_key_header_name: Optional[str] = "X-API-Key"
+    auth_value: Optional[str] = None
 
 class AIAgentConnectivityDetailsA2A(AIAgentConnectivityDetailsBase):
     agent_url: str


### PR DESCRIPTION
## Purpose
Introduce new agent connectivity capabilities to support **Agent2Agent (A2A)** and **curl-based** agents, enabling standardized auth and header handling for inter-agent calls.

## Key changes
- Added `AIAgentConnectivityDetailsA2A` model inheriting from `AIAgentConnectivityDetailsBase`
- Defined defaults for A2A connectivity:
  - `custom_headers: Dict[str, str] = {}`
  - `auth_type: AIAgentConnectivityDetailsA2AAuthType = NoAuth`
  - `api_key_header_name: "X-API-Key"`
  - `auth_value: Optional[str] = None`
- Introduced `agent_url: str` field for A2A connectivity target
- Commit: **feat(PRO-452): added new agent types (a2a and curl) + connectivity details**

## Notes
- No DB migrations expected (model additions remain within SDK layer)
- Ensure downstream services honor default headers and auth semantics
- Consider security review for token handling when `auth_type` ≠ NoAuth

## Testing
- Unit: add tests for `AIAgentConnectivityDetailsA2A` defaults and required fields
- Manual: instantiate an A2A agent with/without auth; validate headers and request flow to `agent_url`

## Follow-ups
- PRO-452: implement OAuth2 and API key auth flows for A2A
- Add curl agent execution adapter and e2e tests
- Document connectivity configuration in SDK README

## Screenshots
<!-- Paste screenshots here if applicable -->
