### PR TITLE
chore(PRO-465): simplify MCP tool resolution in agno backend

### DIFF
--- a/src/xpander_sdk/modules/backend/frameworks/agno.py
+++ b/src/xpander_sdk/modules/backend/frameworks/agno.py
@@ -616,6 +616,4 @@ async def _resolve_agent_tools(agent: Agent, task: Optional[Task] = None) -> Lis
                 )
             )
 
-    return agent.tools.functions + await asyncio.gather(
-        *[mcp.__aenter__() for mcp in mcp_tools]
-    )
+    return agent.tools.functions + mcp_tools


### PR DESCRIPTION
## Purpose
Streamline agent tool initialization by returning MCP tools directly instead of awaiting their async context managers. This reduces unnecessary async overhead and clarifies tool resolution flow.

## Key changes
- Replaced `await asyncio.gather(*[mcp.__aenter__() for mcp in mcp_tools])` with direct `mcp_tools` return
- Kept concatenation with `agent.tools.functions` intact
- Net change: 1 addition, 3 deletions in `src/xpander_sdk/modules/backend/frameworks/agno.py`

## Notes
- Behavior change: MCP tools are no longer awaited via `__aenter__`; ensure upstream code does not depend on side effects from entering async contexts
- Potential impact if MCP tools require explicit async init; confirm MCP providers handle lazy initialization or are pre-initialized
- No migrations or config changes

## Testing
- Unit: add/adjust tests to verify `_resolve_agent_tools` returns ready-to-use tools without awaiting context managers
- Manual: run an agent that uses MCP tools and confirm tools execute successfully and no warnings about unentered contexts

## Follow-ups
- Audit MCP tool lifecycle: introduce explicit init hook if any provider needs setup
- Update docs for agent tool resolution to reflect non-await behavior
