### PR TITLE
feat(PRO-506): add task activity log retrieval and models; docs and SDK integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ tasks = Tasks(configuration=config)
 task = await tasks.aget("task-id")
 await task.aset_status(AgentExecutionStatus.Running)
 await task.asave()
+
+# Retrieve task activity log
+activity_log = await task.aget_activity_log()
+for message in activity_log.messages:
+    print(f"{message.role}: {message.content.text}")
 ```
 
 ### 4. Tools Integration
@@ -236,6 +241,35 @@ task = await agent.acreate_task(
 async for event in task.aevents():
     print(f"Event Type: {event.type}")
     print(f"Event Data: {event.data}")
+```
+
+### Task Activity Monitoring
+
+```python
+from xpander_sdk import Task
+
+# Load a completed task
+task = await Task.aload("task-id")
+
+# Get detailed activity log
+activity_log = await task.aget_activity_log()
+
+# Analyze messages between user and agent
+for message in activity_log.messages:
+    if hasattr(message, 'role'):
+        print(f"{message.role}: {message.content.text}")
+    elif hasattr(message, 'tool_name'):
+        # Tool call
+        print(f"Tool: {message.tool_name}")
+        print(f"Payload: {message.payload}")
+        print(f"Result: {message.result}")
+    elif hasattr(message, 'type'):
+        # Reasoning step
+        print(f"Reasoning ({message.type}): {message.thought}")
+
+# Synchronous version
+task = Task.load("task-id")
+activity_log = task.get_activity_log()
 ```
 
 ### Local Task Testing

--- a/src/xpander_sdk/consts/api_routes.py
+++ b/src/xpander_sdk/consts/api_routes.py
@@ -35,6 +35,7 @@ and deleting resources.
     ListTasks = "/agent-execution/executions/history/{agent_id}"
     ListUserTasks = "/agent-execution/executions/history/user/{user_id}"
     GetTask = "/agent-execution/{task_id}/status"
+    GetTaskActivityLog = "/activity/{agent_id}/{task_id}"
     TaskCrud = "/agent-execution/{agent_or_task_id}"
     UpdateTask = "/agent-execution/{task_id}/update"
     ReportExternalTask = "/agent-execution/{agent_id}/report_task"

--- a/src/xpander_sdk/models/activity.py
+++ b/src/xpander_sdk/models/activity.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+from enum import Enum
+from typing import Any, List, Literal, Optional, Union
+
+from xpander_sdk.models.events import ToolCallRequestReasoning
+from xpander_sdk.models.shared import XPanderSharedModel
+from xpander_sdk.models.user import User
+from xpander_sdk.modules.tools_repository.models.mcp import MCPOAuthGetTokenResponse
+
+class AgentActivityThreadMessageContent(XPanderSharedModel):
+    text: Optional[str] = None
+    files: Optional[List[str]] = []
+
+class AgentActivityThreadMessage(XPanderSharedModel):
+    id: str
+    created_at: datetime
+    role: Literal["user","agent"]
+    content: AgentActivityThreadMessageContent
+
+class AgentActivityThreadToolCall(XPanderSharedModel):
+    id: str
+    created_at: datetime
+    tool_name: str
+    payload: Any
+    is_error: Optional[bool] = False
+    reasoning: Optional[ToolCallRequestReasoning] = None
+    result: Optional[Any] = None
+
+class AgentActivityThreadReasoningType(str, Enum):
+    Think = "think"
+    Analyze = "analyze"
+
+class AgentActivityThreadReasoning(XPanderSharedModel):
+    id: str
+    created_at: datetime
+    type: AgentActivityThreadReasoningType
+    title: str
+    confidence: float
+    thought: Optional[str] = None
+    action: Optional[str] = None
+    result: Optional[str] = None
+    analysis: Optional[str] = None
+
+class AgentActivityThreadSubAgentTrigger(XPanderSharedModel):
+    id: str
+    created_at: datetime
+    agent_id: str
+    query: Optional[str] = None
+    files: Optional[List[str]] = []
+    reasoning: ToolCallRequestReasoning
+
+class AgentActivityThreadAuth(MCPOAuthGetTokenResponse):
+    id: str
+    created_at: datetime
+
+AgentActivityThreadMessageType = Union[AgentActivityThreadMessage, AgentActivityThreadToolCall, AgentActivityThreadReasoning, AgentActivityThreadSubAgentTrigger, AgentActivityThreadAuth]
+class AgentActivityThread(XPanderSharedModel):
+    id: str
+    created_at: datetime
+    messages: List[AgentActivityThreadMessageType]
+    user: Optional[User] = None
+
+class AgentActivityThreadListItem(XPanderSharedModel):
+    id: str
+    created_at: datetime


### PR DESCRIPTION
## Purpose
Expose a structured activity log for agent tasks to improve observability, debugging, and post‑execution analysis, with async/sync access via the SDK and developer documentation/examples.

## Key changes
- Added API route `GetTaskActivityLog = "/activity/{agent_id}/{task_id}"`.
- Introduced activity thread models:
  - `AgentActivityThread` and union message types (user/agent messages, tool calls, reasoning steps, sub‑agent triggers, auth events).
- Implemented SDK methods on `Task`:
  - `aget_activity_log()` (async) and `get_activity_log()` (sync) to fetch full activity threads.
- Extended `Task` helpers:
  - File/image/readable file retrieval refactors for Agno integration and content injection.
  - Minor cleanup and formatting in events streaming and metrics reporting.
- Updated documentation:
  - README: examples for retrieving and iterating activity logs.
  - `modules/tasks/AGENTS.md`: patterns for handling different message types and best practices.

## Notes
- No DB migrations.
- New endpoint requires valid `agent_id` and `task_id`.
- Activity logs can be large; consumers should process efficiently and prefer async methods.
- Errors surfaced as `ModuleException` with underlying `HTTPStatusError` where applicable.

## Testing
- Manual verification: load completed tasks and fetch activity logs using both async and sync methods.
- Validate parsing for message variants (role/tool_name/type/sub‑agent/auth).
- Confirm metrics reporting and event streaming unchanged functionally.

## Follow-ups
- PRO-506: add pagination/filters for activity threads (time range, type).
- Extend unit tests for activity models and SDK retrieval.
- Consider batching and partial fetch for very large logs.
