### PR TITLE
feat(PRO-509): add configurable LLM reasoning effort with agno passthrough

### DIFF
--- a/src/xpander_sdk/modules/agents/models/agent.py
+++ b/src/xpander_sdk/modules/agents/models/agent.py
@@ -383,7 +383,10 @@ class AgentGraphItem(BaseModel):
     llm_settings: Optional[List[AgentGraphItemLLMSettings]] = []
     is_first: Optional[bool] = False
 
-
+class LLMReasoningEffort(str, Enum):
+    Low = "low"
+    Medium = "medium"
+    High = "high"
 
 class AIAgentConnectivityDetailsA2AAuthType(str, Enum):
     NoAuth = "none"

--- a/src/xpander_sdk/modules/agents/sub_modules/agent.py
+++ b/src/xpander_sdk/modules/agents/sub_modules/agent.py
@@ -40,6 +40,7 @@ from xpander_sdk.modules.agents.models.agent import (
     AgentType,
     DatabaseConnectionString,
     LLMCredentials,
+    LLMReasoningEffort,
 )
 from xpander_sdk.modules.agents.models.knowledge_bases import AgentKnowledgeBase
 from xpander_sdk.modules.knowledge_bases.knowledge_bases_module import KnowledgeBases
@@ -151,6 +152,7 @@ class Agent(XPanderSharedModel):
             using_nemo: Optional[bool]
             model_provider: str
             model_name: str
+            llm_reasoning_effort: Optional[LLMReasoningEffort] = LLMReasoningEffort.Medium
             llm_api_base: Optional[str]
             webhook_url: Optional[str]
             created_at: Optional[datetime]
@@ -192,6 +194,7 @@ class Agent(XPanderSharedModel):
     using_nemo: Optional[bool] = False
     model_provider: str
     model_name: str
+    llm_reasoning_effort: Optional[LLMReasoningEffort] = LLMReasoningEffort.Medium
     llm_api_base: Optional[str] = None
     webhook_url: Optional[str] = None
     created_at: Optional[datetime] = None

--- a/src/xpander_sdk/modules/backend/frameworks/agno.py
+++ b/src/xpander_sdk/modules/backend/frameworks/agno.py
@@ -8,7 +8,7 @@ from loguru import logger
 from xpander_sdk import Configuration
 from xpander_sdk.models.shared import OutputFormat, ThinkMode
 from xpander_sdk.modules.agents.agents_module import Agents
-from xpander_sdk.modules.agents.models.agent import AgentGraphItemType
+from xpander_sdk.modules.agents.models.agent import AgentGraphItemType, LLMReasoningEffort
 from xpander_sdk.modules.agents.sub_modules.agent import Agent
 from xpander_sdk.modules.backend.utils.mcp_oauth import authenticate_mcp_server
 from xpander_sdk.modules.tasks.sub_modules.task import Task
@@ -278,6 +278,10 @@ def _load_llm_model(agent: Agent, override: Optional[Dict[str, Any]]) -> Any:
             return env_llm_key or agent.llm_credentials.value
 
     llm_args = {}
+    
+    if agent.llm_reasoning_effort and agent.llm_reasoning_effort != LLMReasoningEffort.Medium:
+        llm_args = { "reasoning_effort": agent.llm_reasoning_effort.value }
+    
     if agent.llm_api_base and len(agent.llm_api_base) != 0:
         llm_args["base_url"] = agent.llm_api_base
     


### PR DESCRIPTION
## Purpose
Introduce a first-class, configurable "reasoning effort" for agents’ LLM calls to improve control over cost/latency vs. depth of reasoning, and pass this through to the agno backend only when non-default.

## Key changes
- Added `LLMReasoningEffort` enum (`low`, `medium`, `high`) in `Agent` model
- Extended `Agent` to include `llm_reasoning_effort` with default `Medium`
- Updated agno framework to forward `reasoning_effort` in `llm_args` when not `Medium`
- Preserved optional `base_url` passthrough via `llm_api_base`

## Notes
- Backward compatible: default remains `Medium` and no extra args are sent in that case
- Enables fine-grained tuning of agent behavior without breaking existing configs
- No DB migrations indicated; model change is additive

## Testing
- Manual: create/update an Agent with `llm_reasoning_effort=Low/High` and verify agno sends `{"reasoning_effort": "<value>"}` only when not `Medium`
- Manual: ensure `llm_api_base` continues to set `base_url` in `llm_args`
- Suggested: unit tests for `Agent` defaults and agno argument construction

## Follow-ups
- Consider exposing effort selection in UI and API docs
- Evaluate provider-specific mappings if additional effort levels emerge
