### PR TITLE
feat(PRO-559): add auth event callbacks, global decorator, and MCP OAuth flow handling

### DIFF
--- a/src/xpander_sdk/__init__.py
+++ b/src/xpander_sdk/__init__.py
@@ -17,6 +17,7 @@ For more information, visit: https://xpander.ai
 
 # Backend-related imports
 from .modules.backend.backend_module import Backend
+from .modules.backend.decorators.on_auth_event import on_auth_event
 
 # Agent-related imports
 from .modules.agents.agents_module import Agents, Agent, AgentsListItem
@@ -53,6 +54,7 @@ from .models.shared import OutputFormat, Tokens
 __all__ = [
     # xpander.ai Backend
     "Backend",
+    "on_auth_event",
     # Agent management
     "Agents",
     "Agent",

--- a/src/xpander_sdk/modules/backend/__init__.py
+++ b/src/xpander_sdk/modules/backend/__init__.py
@@ -1,0 +1,8 @@
+"""
+Backend module for xpander.ai SDK.
+"""
+
+from .backend_module import Backend
+from .decorators.on_auth_event import on_auth_event
+
+__all__ = ["Backend", "on_auth_event"]

--- a/src/xpander_sdk/modules/backend/decorators/__init__.py
+++ b/src/xpander_sdk/modules/backend/decorators/__init__.py
@@ -1,0 +1,7 @@
+"""
+Backend module decorators.
+"""
+
+from .on_auth_event import on_auth_event
+
+__all__ = ["on_auth_event"]

--- a/src/xpander_sdk/modules/backend/decorators/on_auth_event.py
+++ b/src/xpander_sdk/modules/backend/decorators/on_auth_event.py
@@ -1,0 +1,131 @@
+"""
+xpander_sdk.modules.backend.decorators.on_auth_event
+
+This module provides the `@on_auth_event` decorator, which allows developers to define
+authentication event handlers that respond to OAuth flows and authentication events.
+
+The decorator ensures that the registered function:
+- Accepts three parameters: agent (Agent), task (Task), and event (TaskUpdateEvent)
+- Handles authentication events (e.g., MCP OAuth flows requiring user login)
+- Can be either synchronous or asynchronous
+
+Execution Notes:
+- The handler is called when authentication events occur (e.g., OAuth login required)
+- The event.type will always be "auth_event"
+- The event.data contains authentication-specific information (e.g., OAuth login URL)
+- Use this for displaying authentication prompts, handling OAuth flows, etc.
+
+Example usage:
+--------------
+>>> from xpander_sdk import Backend, on_auth_event
+>>> 
+>>> # Define handler with decorator - auto-registers globally
+>>> @on_auth_event
+... async def handle_auth(agent, task, event):
+...     print(f"Authentication required for {agent.name}")
+...     print(f"Login URL: {event.data.get('auth_url')}")
+...     # Display authentication prompt to user
+>>> 
+>>> # Handler is automatically invoked when auth events occur
+>>> backend = Backend()
+>>> args = await backend.aget_args(agent_id="agent-123")  # handle_auth is called automatically
+"""
+
+from functools import wraps
+from inspect import iscoroutinefunction, signature
+from typing import Optional, Callable
+
+from xpander_sdk.modules.agents.sub_modules.agent import Agent
+from xpander_sdk.modules.tasks.sub_modules.task import Task, TaskUpdateEvent
+from xpander_sdk.modules.backend.events_registry import EventsRegistry, EventType
+
+
+def on_auth_event(_func: Optional[Callable] = None):
+    """
+    Decorator to register a handler for authentication events.
+
+    The decorated function is automatically registered globally and will be called
+    whenever authentication events occur during agent execution (e.g., MCP OAuth flows
+    requiring user login). The function:
+    - Must accept three parameters: agent (Agent), task (Task), event (TaskUpdateEvent)
+    - Can be either synchronous or asynchronous
+    - Receives only authentication events (event.type == "auth_event")
+    - Is invoked automatically - no need to pass it to aget_args/get_args
+
+    Args:
+        _func (Optional[Callable]):
+            The function to decorate (for direct usage like `@on_auth_event`).
+
+    Raises:
+        TypeError: If the decorated function does not have the correct parameters.
+
+    Example:
+        >>> @on_auth_event
+        ... async def handle_oauth_login(agent, task, event):
+        ...     print(f"Agent: {agent.name}")
+        ...     print(f"Task: {task.id}")
+        ...     print(f"Auth data: {event.data}")
+        ...     # Handle OAuth flow
+        
+        >>> @on_auth_event
+        ... def sync_auth_handler(agent, task, event):
+        ...     if 'auth_url' in event.data:
+        ...         print(f"Please visit: {event.data['auth_url']}")
+    """
+
+    def decorator(func: Callable) -> Callable:
+        sig = signature(func)
+        params = list(sig.parameters.keys())
+
+        # Validate function signature
+        if len(params) < 3:
+            raise TypeError(
+                f"Function '{func.__name__}' must accept 3 parameters: agent, task, event. "
+                f"Got {len(params)} parameters: {params}"
+            )
+
+        # Store the original function for later use
+        @wraps(func)
+        async def async_wrapper(agent: Agent, task: Task, event: TaskUpdateEvent):
+            return await func(agent, task, event)
+
+        @wraps(func)
+        def sync_wrapper(agent: Agent, task: Task, event: TaskUpdateEvent):
+            return func(agent, task, event)
+
+        wrapped = async_wrapper if iscoroutinefunction(func) else sync_wrapper
+        
+        # Mark the function as an auth event handler
+        wrapped._is_auth_event_handler = True
+        
+        # Register the handler in the singleton registry
+        registry = EventsRegistry()
+        registry.register_auth_event(wrapped)
+        
+        return wrapped
+
+    if _func and callable(_func):
+        return decorator(_func)
+
+    return decorator
+
+
+def get_registered_handlers():
+    """
+    Get all registered authentication event handlers.
+    
+    Returns:
+        list: List of registered handler functions.
+    """
+    registry = EventsRegistry()
+    return registry.get_auth_handlers()
+
+
+def clear_handlers():
+    """
+    Clear all registered authentication event handlers.
+    
+    Useful for testing or when you want to reset the handlers.
+    """
+    registry = EventsRegistry()
+    registry.clear(EventType.AUTH_EVENT)

--- a/src/xpander_sdk/modules/backend/events_registry.py
+++ b/src/xpander_sdk/modules/backend/events_registry.py
@@ -1,0 +1,172 @@
+"""
+Events Registry - Singleton pattern for managing event handlers and hooks.
+
+This registry supports multiple event types:
+- Authentication events (OAuth flows)
+- Tool call hooks (pre/post/error) - Coming soon
+"""
+
+from typing import Callable, List, Optional, Dict, Any
+from enum import Enum
+import asyncio
+
+
+class EventType(str, Enum):
+    """Supported event types in the backend module."""
+    AUTH_EVENT = "auth_event"
+    TOOL_PRE_CALL = "tool_pre_call"  # Future: before tool execution
+    TOOL_POST_CALL = "tool_post_call"  # Future: after successful tool execution
+    TOOL_ERROR = "tool_error"  # Future: when tool execution fails
+
+
+class EventsRegistry:
+    """
+    Singleton registry for managing event handlers and hooks.
+    
+    This registry maintains handlers for different event types and provides
+    methods to register, retrieve, and invoke them.
+    
+    Supported event types:
+    - AUTH_EVENT: Authentication events (e.g., MCP OAuth flows)
+    - TOOL_PRE_CALL: Before tool execution (future)
+    - TOOL_POST_CALL: After successful tool execution (future)
+    - TOOL_ERROR: When tool execution fails (future)
+    """
+    
+    _instance: Optional['EventsRegistry'] = None
+    _handlers: Dict[EventType, List[Callable]] = {}
+    
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._handlers = {
+                EventType.AUTH_EVENT: [],
+                EventType.TOOL_PRE_CALL: [],
+                EventType.TOOL_POST_CALL: [],
+                EventType.TOOL_ERROR: [],
+            }
+        return cls._instance
+    
+    def register(self, event_type: EventType, handler: Callable) -> None:
+        """
+        Register an event handler for a specific event type.
+        
+        Args:
+            event_type (EventType): The type of event to handle.
+            handler (Callable): The handler function to register.
+        """
+        if event_type not in self._handlers:
+            self._handlers[event_type] = []
+        
+        if handler not in self._handlers[event_type]:
+            self._handlers[event_type].append(handler)
+    
+    def register_auth_event(self, handler: Callable) -> None:
+        """
+        Register an authentication event handler.
+        
+        Args:
+            handler (Callable): The handler function to register.
+        """
+        self.register(EventType.AUTH_EVENT, handler)
+    
+    def get_handlers(self, event_type: EventType) -> List[Callable]:
+        """
+        Get all registered handlers for a specific event type.
+        
+        Args:
+            event_type (EventType): The type of event.
+        
+        Returns:
+            List[Callable]: List of registered handler functions.
+        """
+        return self._handlers.get(event_type, []).copy()
+    
+    def get_auth_handlers(self) -> List[Callable]:
+        """
+        Get all registered authentication event handlers.
+        
+        Returns:
+            List[Callable]: List of registered auth handler functions.
+        """
+        return self.get_handlers(EventType.AUTH_EVENT)
+    
+    def clear(self, event_type: Optional[EventType] = None) -> None:
+        """
+        Clear registered handlers.
+        
+        Args:
+            event_type (Optional[EventType]): If provided, clear only handlers
+                for this event type. If None, clear all handlers.
+        """
+        if event_type:
+            if event_type in self._handlers:
+                self._handlers[event_type].clear()
+        else:
+            for handlers_list in self._handlers.values():
+                handlers_list.clear()
+    
+    async def invoke_handlers(self, event_type: EventType, *args, **kwargs) -> None:
+        """
+        Invoke all registered handlers for a specific event type.
+        
+        Args:
+            event_type (EventType): The type of event to invoke handlers for.
+            *args: Positional arguments to pass to handlers.
+            **kwargs: Keyword arguments to pass to handlers.
+        """
+        handlers = self._handlers.get(event_type, [])
+        
+        for handler in handlers:
+            try:
+                if asyncio.iscoroutinefunction(handler):
+                    await handler(*args, **kwargs)
+                else:
+                    handler(*args, **kwargs)
+            except Exception as e:
+                # Log error but continue with other handlers
+                from loguru import logger
+                logger.error(f"Error in {event_type.value} handler {handler.__name__}: {e}")
+    
+    async def invoke_auth_handlers(self, agent, task, event) -> None:
+        """
+        Invoke all registered authentication event handlers.
+        
+        Args:
+            agent: The Agent object associated with the task.
+            task: The Task object being executed.
+            event: The TaskUpdateEvent containing authentication event data.
+        """
+        await self.invoke_handlers(EventType.AUTH_EVENT, agent, task, event)
+    
+    def has_handlers(self, event_type: EventType) -> bool:
+        """
+        Check if any handlers are registered for a specific event type.
+        
+        Args:
+            event_type (EventType): The type of event.
+        
+        Returns:
+            bool: True if at least one handler is registered, False otherwise.
+        """
+        return len(self._handlers.get(event_type, [])) > 0
+    
+    def has_auth_handlers(self) -> bool:
+        """
+        Check if any authentication event handlers are registered.
+        
+        Returns:
+            bool: True if at least one auth handler is registered, False otherwise.
+        """
+        return self.has_handlers(EventType.AUTH_EVENT)
+    
+    @classmethod
+    def reset(cls) -> None:
+        """
+        Reset the singleton instance.
+        
+        Useful for testing to ensure a clean state.
+        """
+        if cls._instance is not None:
+            cls._instance.clear()
+            cls._instance = None

--- a/src/xpander_sdk/modules/backend/frameworks/dispatch.py
+++ b/src/xpander_sdk/modules/backend/frameworks/dispatch.py
@@ -10,6 +10,7 @@ async def dispatch_get_args(
     override: Optional[Dict[str, Any]] = None,
     tools: Optional[List[Callable]] = None,
     is_async: Optional[bool] = True,
+    auth_events_callback: Optional[Callable] = None,
 ) -> Dict[str, Any]:
     """
     Dispatch to the correct framework-specific argument resolver.
@@ -20,6 +21,7 @@ async def dispatch_get_args(
         override (Optional[Dict[str, Any]]): Dict of override values.
         tools (Optional[List[Callable]]): Optional additional tools to be added to the agent arguments.
         is_async (Optional[bool]): Is in Async Context?.
+        auth_events_callback (Optional[Callable]): Optional callback function (async or sync) that receives (agent, task, event) for authentication events only.
 
     Returns:
         Dict[str, Any]: Arguments for instantiating the framework agent.
@@ -28,7 +30,7 @@ async def dispatch_get_args(
     match agent.framework:
         case Framework.Agno:
             from .agno import build_agent_args
-            return await build_agent_args(xpander_agent=agent, task=task, override=override, tools=tools, is_async=is_async)
+            return await build_agent_args(xpander_agent=agent, task=task, override=override, tools=tools, is_async=is_async, auth_events_callback=auth_events_callback)
         # case Framework.Langchain: # PLACEHOLDER
         #     from .langchain import build_agent_args
         #     return await build_agent_args(xpander_agent=agent, task=task, override=override)


### PR DESCRIPTION
## Purpose
Enable real-time handling of authentication flows (e.g., MCP OAuth) by introducing an optional per-call callback and a global decorator-driven handler. Ensure agents can surface login-required events and token readiness to the host application cleanly, improving developer ergonomics and reviewability.

## Key changes
- Added `auth_events_callback` support to `Backend.aget_args()` and `Backend.get_args()`
- Introduced `@on_auth_event` decorator for global auth event handlers
- Implemented singleton `EventsRegistry` to register/invoke auth handlers
- Extended Agno framework dispatch to propagate `auth_events_callback`
- Updated MCP OAuth utilities to:
  - Push `AuthEvent` updates for login-required and token-ready states
  - Invoke both explicit callback and registered handlers (async/sync supported)
  - Redact access tokens in events sent to queue
- Updated docs and READMEs with usage examples (direct function, decorator, combined)
- Exposed `on_auth_event` in package `__init__` and backend module exports

## Notes
- Event type for these flows is always `"auth_event"`
- `TaskUpdateEvent` now carries OAuth-specific data, e.g., login URL and token status
- Polling interval: 1s; max wait for login: 10 minutes
- Future hook points scaffolded in `EventsRegistry` (tool pre/post/error)

## Testing
- Manual: validate that:
  - Decorated handlers fire automatically on login-required
  - Per-call `auth_events_callback` is invoked alongside global handlers
  - Token-ready events are emitted with redacted token data
  - Agno agents receive `tools` correctly when auth is required
- Integration (suggested):
  - Simulate MCP server requiring OAuth; assert `AuthEvent` sequencing
  - Verify handler invocation order and error resilience in registry

## Follow-ups
- Add unit tests for `EventsRegistry` and decorator registration
- Implement tool hook handlers (pre/post/error) in registry
- Document best practices for UI prompts during OAuth flows
