### PR TITLE
feat(PRO-661): support configurable LLM extra headers

### DIFF
--- a/src/xpander_sdk/consts/api_routes.py
+++ b/src/xpander_sdk/consts/api_routes.py
@@ -63,6 +63,9 @@ and deleting resources.
     HITLRequest = "/hitl/request"
     HITLApprove = "/hitl/{task_id}/approve"
     HITLReject = "/hitl/{task_id}/reject"
+    
+    # Metadata
+    GetOrgDefaultLLMExtraHeaders = "/metadata/default_llm_extra_headers"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/src/xpander_sdk/models/orchestrations.py
+++ b/src/xpander_sdk/models/orchestrations.py
@@ -119,6 +119,8 @@ class OrchestrationClassifierNodeLLMSettings(XPanderSharedModel):
         llm_credentials_key: Key identifier for stored credentials.
         llm_credentials_key_type: Type of credential key storage. Defaults to XPander.
         llm_credentials: Direct credential object if not using stored credentials.
+        llm_api_base: Alternative API Base for the LLM.
+        llm_extra_headers: Extra headers to be set to LLM Requests.
     """
 
     model_provider: Optional[LLMModelProvider] = LLMModelProvider.OpenAI
@@ -128,6 +130,8 @@ class OrchestrationClassifierNodeLLMSettings(XPanderSharedModel):
         LLMCredentialsKeyType.XPander
     )
     llm_credentials: Optional[LLMCredentials] = None
+    llm_api_base: Optional[str] = None
+    llm_extra_headers: Optional[Dict[str,str]] = {}
 
 class OrchestrationPointerNode(XPanderSharedModel):
     """Node that references an external asset (agent, function, or orchestration).

--- a/src/xpander_sdk/modules/agents/sub_modules/agent.py
+++ b/src/xpander_sdk/modules/agents/sub_modules/agent.py
@@ -159,6 +159,7 @@ class Agent(XPanderSharedModel):
             deep_planning: Optional[bool] = False
             enforce_deep_planning: Optional[bool] = False
             llm_api_base: Optional[str]
+            llm_extra_headers: Optional[Dict[str,str]]
             webhook_url: Optional[str]
             created_at: Optional[datetime]
             type: Optional[AgentType]
@@ -206,6 +207,7 @@ class Agent(XPanderSharedModel):
     deep_planning: Optional[bool] = False
     enforce_deep_planning: Optional[bool] = False
     llm_api_base: Optional[str] = None
+    llm_extra_headers: Optional[Dict[str,str]] = {}
     webhook_url: Optional[str] = None
     created_at: Optional[datetime] = None
     type: Optional[AgentType] = None


### PR DESCRIPTION
## Purpose
Allow agents and orchestrations to send configurable extra HTTP headers to underlying LLM providers, while supporting organization-wide defaults that can be overridden per agent.

## Key changes
- Added `GetOrgDefaultLLMExtraHeaders` metadata route constant to `APIRoute`
- Extended `OrchestrationClassifierNodeLLMSettings` with `llm_extra_headers` field
- Extended `Agent` model with `llm_extra_headers` attribute (schema + defaults)
- In `agno` backend:
  - Fetch organization default LLM extra headers via `APIClient` and `APIRoute.GetOrgDefaultLLMExtraHeaders`
  - Merge org-level headers with agent-level `llm_extra_headers` (agent overrides org)
  - Pass merged headers via `llm_args["extra_headers"]`
  - For Anthropic, map `extra_headers` into `default_headers`
  - For Amazon Bedrock, strip unsupported `extra_headers` before creating the client

## Notes
- Org-level defaults are retrieved synchronously using `run_sync` around `APIClient.make_request`
- Agent-level `llm_extra_headers` are expected to be a `Dict[str, str]`; they override any colliding org defaults
- For Anthropic, headers are provided through `default_headers` instead of `extra_headers`
- For Amazon Bedrock, extra headers are removed to avoid passing unsupported arguments
- Existing behavior for other providers is preserved aside from the new header injection

## Testing
- Manual: created/updated agents with `llm_extra_headers` and verified merged headers are sent to LLM provider
- Manual: verified behavior with and without org-level default headers
- Manual: smoke-tested Anthropic and Bedrock providers to ensure no invalid args are passed

## Follow-ups
- Add unit tests around header merging and provider-specific handling (Anthropic / Bedrock)
- Extend UI to expose `llm_extra_headers` in agent and orchestration configuration
- Consider validation for reserved or disallowed header names
