### PR TITLE
feat(PRO-668): add secrets manager toggle to MCP server config

### DIFF
--- a/src/xpander_sdk/modules/tools_repository/models/mcp.py
+++ b/src/xpander_sdk/modules/tools_repository/models/mcp.py
@@ -29,6 +29,7 @@ class MCPServerDetails(BaseModel):
     transport: Optional[MCPServerTransport] = MCPServerTransport.HTTP_Transport
     auth_type: Optional[MCPServerAuthType] = MCPServerAuthType._None
     api_key: Optional[str] = None
+    use_secrets_manager: Optional[bool] = False
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
     headers: Optional[Dict] = {}


### PR DESCRIPTION
## Purpose
Allow MCP server configurations in the SDK to indicate whether their secrets are sourced from a secrets manager instead of being provided directly in configuration.

## Key changes
- Added `use_secrets_manager: Optional[bool] = False` to `MCPServerDetails` model in `mcp.py`
- Defaulted the new flag to `False` to preserve existing behavior for current configurations

## Notes
- Backwards compatible: existing configs remain valid with the default `False` value
- Downstream logic (e.g. loading credentials from AWS Secrets Manager or other providers) should respect this flag when resolving MCP server secrets
- No database or storage migrations required

## Testing
- [ ] Confirm MCP configurations still work as before when `use_secrets_manager` is omitted
- [ ] Manually verify that when `use_secrets_manager=True`, the secrets resolution flow uses the secrets manager path

## Follow-ups
- PRO-668: wire this flag into the runtime secrets resolution logic for MCP servers
- Add documentation for MCP configuration showing how and when to use `use_secrets_manager`
