### PR TITLE
feat(PRO-692): add worker capacity autoscaling semaphore for on_task execution

### DIFF
--- a/src/xpander_sdk/modules/events/models/events.py
+++ b/src/xpander_sdk/modules/events/models/events.py
@@ -14,6 +14,7 @@ class EventType(str, Enum):
     AgentExecution = "agent-execution"
     WorkerHeartbeat = "worker-heartbeat"
     WorkerFinished = "worker-finished"
+    WorkerCapacityUpdate = "worker-capacity-update"
     EnvironmentConflict = "worker-environment-conflict"
 
 
@@ -50,6 +51,11 @@ class WorkerHeartbeat(EventMessageBase):
 class WorkerExecutionRequest(EventMessageBase):
     event: EventType = EventType.AgentExecution
     data: Task
+
+
+class WorkerCapacityUpdateEvent(EventMessageBase):
+    event: EventType = EventType.WorkerCapacityUpdate
+    data: dict = {"is_busy": False}
 
 
 class WorkerEnvironmentConflict(EventMessageBase):


### PR DESCRIPTION
## Purpose
Introduce coordinated worker capacity tracking and autoscaling behavior for on_task agent execution, so that concurrent task handling is bounded and the backend is explicitly informed when workers become busy or available.

## Key changes
- Increased default `max_sync_workers` from 4 to 6 in the `Events` module
- Initialized an `asyncio.Semaphore` (`_execution_semaphore`) to gate concurrent task execution based on `max_sync_workers`
- Added `_notify_capacity_status` helper to POST `WorkerCapacityUpdateEvent` with `is_busy` flag to the events backend
- Implemented `_handle_task_with_semaphore` wrapper to ensure semaphore release after each task execution and to notify when capacity becomes available again
- Updated `handle_task_execution_request` and the SSE `AgentExecution` flow to:
  - Acquire the semaphore before scheduling execution
  - Notify the backend when the worker reaches max capacity (`is_busy=True`)
  - Route execution through `_handle_task_with_semaphore` to ensure proper release and availability notifications
- Introduced `WorkerCapacityUpdate` to `EventType` and a `WorkerCapacityUpdateEvent` model for capacity status messages

## Notes
- Capacity tracking is currently tied to `max_sync_workers`; changing this configuration impacts concurrency and the semantics of the semaphore
- Uses `self._execution_semaphore._value` to detect when capacity reaches zero or becomes available again
- Network failures during capacity notifications are logged as warnings but do not block task execution
- No DB migrations are involved; this is SDK/event layer behavior
- Backward compatibility: new event type (`worker-capacity-update`) requires backend support but should be ignored safely by older consumers

## Testing
- Manual: verified that:
  - At most `max_sync_workers` tasks are handled concurrently
  - `worker-capacity-update` is emitted with `is_busy=True` when capacity hits zero
  - `worker-capacity-update` is emitted with `is_busy=False` when capacity is released again
- Logs inspected to confirm correct sequencing of acquire/release and notification calls

## Follow-ups
- Add unit/integration tests around semaphore behavior and `WorkerCapacityUpdateEvent` emission
- Expose `max_sync_workers` and capacity behavior in public SDK docs
- Consider replacing direct `_value` inspection with an explicit capacity counter or helper for better encapsulation
