### PR TITLE
feat(PRO-637): add schema override for workflow action nodes

### DIFF
--- a/src/xpander_sdk/models/orchestrations.py
+++ b/src/xpander_sdk/models/orchestrations.py
@@ -143,6 +143,19 @@ class OrchestrationClassifierNodeLLMSettings(XPanderSharedModel):
     llm_api_base: Optional[str] = None
     llm_extra_headers: Optional[Dict[str,str]] = {}
 
+class SchemaOverride(XPanderSharedModel):
+    """Schema override for workflow action nodes.
+    
+    Allows setting permanent (fixed) values for tool input properties.
+    Fields with permanentValue will be removed from the schema sent to the LLM
+    and the permanent values will be applied to the payload before execution.
+    
+    Attributes:
+        input: Input schema with permanentValue fields to override LLM-generated values.
+    """
+    input: Optional[Dict] = None
+
+
 class OrchestrationPointerNode(XPanderSharedModel):
     """Node that references an external asset (agent, function, or orchestration).
 
@@ -153,6 +166,7 @@ class OrchestrationPointerNode(XPanderSharedModel):
         output_schema: JSON schema for structured output validation.
         instructions: Optional instructions for the pointer node (Action only).
         ignore_response: Should ignore the node result and proceed with previous result?.
+        schema_override: Optional schema override with permanentValue fields for fixed values.
     """
 
     asset_id: str
@@ -167,6 +181,7 @@ class OrchestrationPointerNode(XPanderSharedModel):
     output_schema: Optional[Dict] = None
     instructions: Optional[str] = None
     ignore_response: Optional[bool] = False
+    schema_override: Optional[SchemaOverride] = None
 
 class ClassificationGroup(XPanderSharedModel):
     """A classification group with evaluation criteria and data extraction settings.


### PR DESCRIPTION
## Purpose
Allow workflow action nodes to define fixed values for specific tool input fields, so that some parameters are permanently set by configuration rather than generated by the LLM.

## Key changes
- Introduced `SchemaOverride` model for workflow action nodes
- Documented behavior: `permanentValue` fields are stripped from the schema sent to the LLM and applied to the execution payload
- Extended `OrchestrationPointerNode` with an optional `schema_override` field
- Updated orchestration model docstrings to clarify how overrides are used

## Notes
- This is a backward-compatible change; existing orchestrations without `schema_override` continue to work as-is
- Consumers of the SDK can start passing `schema_override` for finer control over tool inputs
- Actual application of `permanentValue` is expected to be handled in the orchestration runtime logic

## Testing
- Local validation of the updated Pydantic models
- Verified that `OrchestrationPointerNode` still serializes correctly without `schema_override`
- Ensured `schema_override` is optional and does not affect existing payloads

## Follow-ups
- Implement and/or verify runtime logic that:
  - Removes `permanentValue` fields from the schema sent to the LLM
  - Injects permanent values into the execution payload prior to invocation
- Add unit tests around orchestration execution with `schema_override` applied
