### PR TITLE
feat(PRO-702): add OIDC pre-auth configuration to Agent model

### DIFF
--- a/src/xpander_sdk/modules/agents/sub_modules/agent.py
+++ b/src/xpander_sdk/modules/agents/sub_modules/agent.py
@@ -172,6 +172,8 @@ class Agent(XPanderSharedModel):
             orchestration_nodes: Optional[List[OrchestrationNode]] = []
             notification_settings: Optional[NotificationSettings] = {}
             task_level_strategies: Optional[TaskLevelStrategies] = None
+            use_oidc_pre_auth: Optional[bool] = False
+            pre_auth_audiences: Optional[List[str]] = []
 
         Example:
             >>> agent = Agent(id="agent123", name="Example Agent")
@@ -220,6 +222,8 @@ class Agent(XPanderSharedModel):
     orchestration_nodes: Optional[List[OrchestrationNode]] = []
     notification_settings: Optional[NotificationSettings] = {}
     task_level_strategies: Optional[TaskLevelStrategies] = None
+    use_oidc_pre_auth: Optional[bool] = False
+    pre_auth_audiences: Optional[List[str]] = []
 
     _connection_string: Optional[DatabaseConnectionString] = None
 


### PR DESCRIPTION
## Purpose
Introduce configuration flags on the Agent model to support OIDC pre-auth flows and audience scoping for external integrations.

## Key changes
- Added `use_oidc_pre_auth: Optional[bool] = False` to `Agent`
- Added `pre_auth_audiences: Optional[List[str]] = []` to `Agent`
- Updated the Agent docstring/example to include the new fields

## Notes
- Defaults keep existing behavior (`use_oidc_pre_auth=False`, empty audiences list)
- Consumers can start wiring these fields to enable OIDC pre-auth for agents
- No database migrations required if this is a purely in-memory/model-level change

## Testing
- Manual: exercised Agent initialization with and without `use_oidc_pre_auth` and `pre_auth_audiences` to ensure defaults and overrides behave as expected

## Follow-ups
- PRO-702: wire these fields through to the backend auth layer and validate audiences against configured IdP settings
