### PR TITLE
feat(PRO-637): add workflow metrics reporting via agent tasks

### DIFF
--- a/src/xpander_sdk/modules/agents/sub_modules/agent.py
+++ b/src/xpander_sdk/modules/agents/sub_modules/agent.py
@@ -432,6 +432,7 @@ class Agent(XPanderSharedModel):
         title: Optional[str] = None,
         think_mode: Optional[ThinkMode] = ThinkMode.Default,
         disable_attachment_injection: Optional[bool] = False,
+        return_metrics: Optional[bool] = False,
         user_tokens: Optional[Dict] = None
     ) -> Task:
         """
@@ -460,6 +461,7 @@ class Agent(XPanderSharedModel):
             title (Optional[str]): Optional task title.
             think_mode (Optional[ThinkMode]): Optional task think mode, defaults to "default".
             disable_attachment_injection (Optional[bool]): Optional selection if to disable attachment injection to the context window.
+            return_metrics (Optional[bool]): Optional selection if to return metrics report. Available only for Workflow -> Agent invocation
             user_tokens: Optional[Dict]: User tokens to be passed and injected for MCP Auth
 
         Returns:
@@ -499,6 +501,7 @@ class Agent(XPanderSharedModel):
                     "think_mode": think_mode.value,
                     "disable_attachment_injection": disable_attachment_injection,
                     "user_tokens": user_tokens,
+                    "return_metrics": return_metrics
                 },
             )
             return Task(**created_task, configuration=self.configuration)

--- a/src/xpander_sdk/modules/tasks/sub_modules/task.py
+++ b/src/xpander_sdk/modules/tasks/sub_modules/task.py
@@ -195,6 +195,7 @@ class Task(XPanderSharedModel):
     user_tokens: Optional[Dict] = None
     deep_planning: Optional[DeepPlanning] = Field(default_factory=DeepPlanning)
     execution_attempts: Optional[int] = 1
+    return_metrics: Optional[bool] = False
 
     # metrics
     tokens: Optional[Tokens] = None
@@ -764,9 +765,9 @@ class Task(XPanderSharedModel):
                 internal_status=self.internal_status,
                 duration=0.0,
                 ai_model="xpander",
-                api_calls_made=self.used_tools,
+                api_calls_made=[] if self.return_metrics and self.source == "orchestration" else self.used_tools,
                 result=self.result or None,
-                llm_tokens=ExecutionTokens(worker=self.tokens),
+                llm_tokens=ExecutionTokens() if self.return_metrics and self.source == "orchestration" else ExecutionTokens(worker=self.tokens),
             )
 
             await client.make_request(

--- a/src/xpander_sdk/modules/tasks/tasks_module.py
+++ b/src/xpander_sdk/modules/tasks/tasks_module.py
@@ -243,6 +243,7 @@ class Tasks(ModuleBase):
         title: Optional[str] = None,
         think_mode: Optional[ThinkMode] = ThinkMode.Default,
         disable_attachment_injection: Optional[bool] = False,
+        return_metrics: Optional[bool] = False,
         user_tokens: Optional[Dict] = None
     ) -> Task:
         """
@@ -275,6 +276,7 @@ class Tasks(ModuleBase):
             title (Optional[str]): Optional task title.
             think_mode (Optional[ThinkMode]): Optional task think mode, defaults to "default".
             disable_attachment_injection (Optional[bool]): Optional selection if to disable attachment injection to the context window.
+            return_metrics (Optional[bool]): Optional selection if to return metrics report. Available only for Workflow -> Agent invocation
             user_tokens: Optional[Dict]: User tokens to be passed and injected for MCP Auth
 
         Returns:
@@ -324,7 +326,8 @@ class Tasks(ModuleBase):
                     "title": title,
                     "think_mode": think_mode.value,
                     "disable_attachment_injection": disable_attachment_injection,
-                    "user_tokens": user_tokens
+                    "user_tokens": user_tokens,
+                    "return_metrics": return_metrics
                 },
             )
             return Task(**created_task, configuration=self.configuration)


### PR DESCRIPTION
## Purpose
Enable workflow-level metrics reporting when tasks are executed on behalf of an agent, while avoiding double-counting of tokens and API calls originating from orchestration.

## Key changes
- Extended `Agent.acreate_task` to accept `return_metrics` and `user_tokens` and forward them into task creation payloads.
- Extended `TasksModule.acreate` to include `return_metrics` alongside `user_tokens` when creating tasks.
- Updated `Task` model to store `return_metrics` flag.
- Adjusted `Task.areport_metrics` to:
  - Skip reporting `api_calls_made` when `return_metrics` is enabled for orchestration-sourced tasks.
  - Avoid sending worker token usage (`ExecutionTokens(worker=self.tokens)`) in the same orchestration + `return_metrics` scenario.

## Notes
- This change is intended for Workflow → Agent invocations where metrics are reported at the workflow level and should not be double-counted from the agent side.
- Existing behavior for non-orchestration tasks remains unchanged.
- No schema migrations are required; `return_metrics` is handled as an optional field in the SDK model.
- Downstream consumers relying on `api_calls_made` or `llm_tokens` for orchestration tasks should be aware that these fields may now be empty when `return_metrics=True`.

## Testing
- Manually verified that:
  - Creating tasks via agent with `return_metrics=True` correctly propagates the flag.
  - Orchestration tasks with `return_metrics=True` do not send `api_calls_made` or worker `llm_tokens` in metrics reports.
  - Non-orchestration tasks and tasks with `return_metrics=False` still report metrics as before.

## Follow-ups
- Add explicit unit/integration tests around `areport_metrics` to validate the new orchestration + `return_metrics` behavior.
- Consider exposing higher-level helpers for workflow/agent metrics aggregation in the SDK.
