### PR TITLE
feat(PRO-637): add workflow event duplication prevention settings

### DIFF
--- a/src/xpander_sdk/models/orchestrations.py
+++ b/src/xpander_sdk/models/orchestrations.py
@@ -115,6 +115,29 @@ class OrchestrationCondition(XPanderSharedModel):
     path: Optional[str] = None
     value: Optional[Any] = None
 
+class DuplicationPreventionSettings(XPanderSharedModel):
+    """Settings for preventing duplicate event processing in workflows.
+    
+    When enabled, this prevents the same event from triggering a workflow multiple times
+    within a configured time window. Useful for webhooks from services like Stigg or Cal.com
+    that may fire the same event multiple times.
+    
+    Attributes:
+        enabled: Whether duplication prevention is active.
+        ttl_minutes: Time window to consider events as duplicates (default: 10 minutes).
+        selectors: List of dot-notation paths to extract unique ID components from input.
+                   Multiple selectors are combined to form a composite key.
+                   Examples:
+                   - ["messageId"] - single field
+                   - ["input.event_id", "input.user_id"] - composite key
+                   - ["triggerEvent", "payload.uid"] - Cal.com style
+    """
+    
+    enabled: Optional[bool] = False
+    ttl_minutes: Optional[int] = 10
+    selectors: List[str]  # Required - paths to extract unique identifier components
+
+
 class OrchestrationRetryStrategy(XPanderSharedModel):
     """Strategy for retrying failed orchestration nodes.
 

--- a/src/xpander_sdk/modules/agents/models/agent.py
+++ b/src/xpander_sdk/modules/agents/models/agent.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import Dict, List, Literal, Optional, Type
 from pydantic import BaseModel, computed_field
 
-from xpander_sdk.models.orchestrations import OrchestrationIterativeStrategy, OrchestrationRetryStrategy, OrchestrationStopStrategy
+from xpander_sdk.models.orchestrations import DuplicationPreventionSettings, OrchestrationIterativeStrategy, OrchestrationRetryStrategy, OrchestrationStopStrategy
 from xpander_sdk.models.shared import XPanderSharedModel
 from xpander_sdk.modules.tools_repository.models.mcp import MCPServerDetails
 
@@ -508,3 +508,4 @@ class TaskLevelStrategies(XPanderSharedModel):
     stop_strategy: Optional[OrchestrationStopStrategy] = None
     max_runs_per_day: Optional[int] = None
     agentic_context_enabled: Optional[bool] = False
+    duplication_prevention: Optional[DuplicationPreventionSettings] = None


### PR DESCRIPTION
## Purpose
Introduce a configurable duplication prevention mechanism for workflow orchestrations to avoid processing the same external event multiple times within a defined time window.

## Key changes
- Added `DuplicationPreventionSettings` Pydantic model under `xpander_sdk.models.orchestrations` with:
  - `enabled` flag
  - `ttl_minutes` time window (default 10 minutes)
  - `selectors` list for building composite deduplication keys from input paths
- Extended `TaskLevelStrategies` in `xpander_sdk.modules.agents.models.agent` to include an optional `duplication_prevention` field.
- Updated imports in `agent.py` to pull `DuplicationPreventionSettings` from the orchestrations module.

## Notes
- Designed for webhook-style integrations (e.g. Stigg, Cal.com) that may emit the same event multiple times.
- `selectors` is required and will be used to construct a unique key based on event payload paths (e.g. `messageId`, `input.event_id`, `triggerEvent`, `payload.uid`).
- No database schema changes are introduced in this SDK layer, but runtime services must implement the underlying deduplication storage and TTL eviction based on these settings.

## Testing
- TODO: Add/extend unit tests around orchestration/task configuration serialization to ensure `DuplicationPreventionSettings` is correctly propagated and validated.
- Manual: configure a workflow with `duplication_prevention.enabled = true` and verify that repeated events with the same composite key are only processed once within `ttl_minutes`.

## Follow-ups
- Implement and document concrete deduplication backend behavior in the orchestrator service.
- Add higher-level examples and recipes for common providers (Stigg, Cal.com) demonstrating recommended `selectors` configurations.
