### PR TITLE
feat(PRO-722): add Azure AI Foundary support for agno LLM provider

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,8 @@ nest-asyncio
 mcp
 openai
 anthropic
+azure-ai-inference
+aiohttp
 packaging
 fireworks-ai
 google-genai

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     extras_require={
         "agno": ["agno==2.3.26", "sqlalchemy" ,"psycopg[binary,pool]", "greenlet"],
-        "dev": ["black", "pre-commit", "pytest", "anthropic", "mcp", "openai", "fireworks-ai", "aioboto3", "google-genai"],
+        "dev": ["black", "pre-commit", "pytest", "anthropic", "mcp", "openai", "fireworks-ai", "aioboto3", "google-genai", "azure-ai-inference", "aiohttp"],
     },
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/src/xpander_sdk/models/generic.py
+++ b/src/xpander_sdk/models/generic.py
@@ -16,6 +16,7 @@ class LLMModelProvider(Enum):
     OpenAI = "openai"
     NvidiaNIM = "nim"
     AmazonBedrock = "amazon_bedrock"
+    AzureAIFoundary = "azure_ai_foundary"
     HuggingFace = "huggingFace"
     FriendliAI = "friendlyAI"
     Anthropic = "anthropic"


### PR DESCRIPTION
## Purpose
Add first-class support for using Azure AI Foundary as an LLM provider for agno-based agents in the xpander SDK, including dependency wiring and provider enum integration.

## Key changes
- Added `azure-ai-inference` and `aiohttp` to core dependencies (`requirements.txt`)
- Included `azure-ai-inference` and `aiohttp` in the `dev` extras in `setup.py`
- Extended `LLMModelProvider` enum with `AzureAIFoundary = "azure_ai_foundary"`
- Implemented Azure AI Foundary provider branch in `agno._load_llm_model`:
  - Reads API key from `llm_args.extra_headers.Authorization`/`authorization` or `AZURE_API_KEY` via `get_llm_key`
  - Requires and validates `base_url` argument
  - Normalizes API key by stripping `Bearer`/`bearer` prefixes
  - Maps `base_url` to `azure_endpoint` for `AzureAIFoundry` model
  - Instantiates `AzureAIFoundry` with model id, endpoint, API key, and retry configuration

## Notes
- Azure AI Foundary usage requires:
  - Valid API key via headers (Authorization) or `AZURE_API_KEY` LLM Key
  - `base_url` parameter provided in LLM args
- `extra_headers` are removed from `llm_args` before constructing the `AzureAIFoundry` model to avoid leaking raw headers downstream.
- Provider string is matched as `"azure_ai_foundary"`; callers must use this exact provider identifier.
- No database schema or migration changes.

## Testing
- Manual: verified that agents configured with `model_provider="azure_ai_foundary"` and a valid API key + base URL can be instantiated without errors.
- Manual: validated error paths when:
  - API key is missing
  - `base_url` is missing
- (Add/extend automated tests for `agno._load_llm_model` Azure branch as needed.)

## Follow-ups
- Add unit tests covering Azure AI Foundary initialization, error handling, and header normalization.
- Document configuration examples for Azure AI Foundary in the SDK docs / README.
